### PR TITLE
RSDEV-664: refactor OAuthToken class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,8 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>rspace-core-model</artifactId>
-  <version>2.10.0</version>
+  <artifactId>rspace-core-model-rsdev-664</artifactId>
+  <version>2.11.0-SNAPSHOT</version>
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,8 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>rspace-core-model-rsdev-664</artifactId>
-  <version>2.11.0-SNAPSHOT</version>
+  <artifactId>rspace-core-model</artifactId>
+  <version>2.11.1</version>
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>

--- a/src/main/java/com/researchspace/model/User.java
+++ b/src/main/java/com/researchspace/model/User.java
@@ -184,6 +184,8 @@ public class User extends AbstractUserOrGroupImpl
 	@Setter
 	private String token; // used to back signup form in cloud version
 	@Setter
+	private UserAuthenticationMethod authenticatedBy;
+	@Setter
 	private List<User> connectedUsers;
 	@Setter
 	private List<Group> connectedGroups;
@@ -228,12 +230,19 @@ public class User extends AbstractUserOrGroupImpl
 	/**
 	 * Getter for verification token; this is used to verify cloud-based signup
 	 * and is only relevant in cloud-deployment.
-	 * 
-	 * @return
 	 */
 	@Transient
 	public String getToken() {
 		return token;
+	}
+
+	/**
+	 * Getter for authentication method that was used for logging this user into RSpace;
+	 * only relevant/populated for User object pointing to a subject executing the code
+	 */
+	@Transient
+	public UserAuthenticationMethod getAuthenticatedBy() {
+		return authenticatedBy;
 	}
 
 	/**

--- a/src/main/java/com/researchspace/model/User.java
+++ b/src/main/java/com/researchspace/model/User.java
@@ -237,8 +237,8 @@ public class User extends AbstractUserOrGroupImpl
 	}
 
 	/**
-	 * Getter for authentication method that was used for logging this user into RSpace;
-	 * only relevant/populated for User object pointing to a subject executing the code
+	 * If this object represents the currently logged-in User, this method may store
+	 * info about authentication method used for logging the user into RSpace.
 	 */
 	@Transient
 	public UserAuthenticationMethod getAuthenticatedBy() {

--- a/src/main/java/com/researchspace/model/UserApiKey.java
+++ b/src/main/java/com/researchspace/model/UserApiKey.java
@@ -38,7 +38,6 @@ public class UserApiKey implements Serializable {
 	private User user;
 
 	public UserApiKey(User user, String apiKey) {
-		super();
 		this.apiKey = apiKey;
 		this.user = user;
 		this.created = new Date();

--- a/src/main/java/com/researchspace/model/UserAuthenticationMethod.java
+++ b/src/main/java/com/researchspace/model/UserAuthenticationMethod.java
@@ -1,0 +1,16 @@
+package com.researchspace.model;
+
+/**
+ * Various ways User got authenticated within RSpace
+ */
+public enum UserAuthenticationMethod {
+
+	SHIRO_SESSION,
+
+	API_KEY,
+
+	API_OAUTH_TOKEN,
+
+	UI_OAUTH_TOKEN;
+
+}

--- a/src/main/java/com/researchspace/model/oauth/OAuthToken.java
+++ b/src/main/java/com/researchspace/model/oauth/OAuthToken.java
@@ -4,7 +4,6 @@ import static org.apache.commons.lang.StringUtils.isBlank;
 
 import java.io.Serializable;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 
 import java.util.Date;
 import javax.persistence.Column;
@@ -13,12 +12,9 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
-import javax.persistence.Table;
 import javax.persistence.Transient;
-import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.Size;
 
-import lombok.Data;
 import org.apache.commons.lang3.Validate;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.hibernate.annotations.Cache;

--- a/src/main/java/com/researchspace/model/oauth/OAuthToken.java
+++ b/src/main/java/com/researchspace/model/oauth/OAuthToken.java
@@ -82,7 +82,7 @@ public class OAuthToken implements Serializable, AuthenticationToken {
 	 * Public constructor with all required fields.
 	 */
 	public OAuthToken(User user, String clientId, OAuthTokenType tokenType) {
-		Validate.noNullElements(new Object[]{user, clientId, tokenType}, "No null arguments");
+		Validate.noNullElements(new Object[]{user, clientId, tokenType}, "userId/clientId/tokenType cannot be null");
 		Validate.isTrue(!isBlank(clientId), "client ID must be non-empty");
 		this.user = user;
 		this.clientId = clientId;

--- a/src/main/java/com/researchspace/model/oauth/OAuthToken.java
+++ b/src/main/java/com/researchspace/model/oauth/OAuthToken.java
@@ -94,11 +94,6 @@ public class OAuthToken implements Serializable, AuthenticationToken {
 		this.created = new Date();
 	}
 
-	public void setExpiryTime(Instant expiryTime) {
-		Validate.isTrue(expiryTime == null || expiryTime.isAfter(Instant.now()), "expiry time must be in the future ");
-		this.expiryTime = expiryTime;
-	}
-
 	public void setHashedAccessToken(String hashedAccessToken) {
 		Validate.isTrue(!isBlank(hashedAccessToken) || hashedAccessToken == null, "access token must be non-empty");
 		this.hashedAccessToken = hashedAccessToken;

--- a/src/main/java/com/researchspace/model/oauth/OAuthTokenType.java
+++ b/src/main/java/com/researchspace/model/oauth/OAuthTokenType.java
@@ -1,0 +1,17 @@
+package com.researchspace.model.oauth;
+
+/**
+ * Origin of oauth token
+ */
+public enum OAuthTokenType {
+
+	/**
+	 * Token to be used by RSpace UI, generated during shiro-authenticated user session */
+	UI_TOKEN,
+
+	/**
+	 * Token to be used by external API clients, generated with /oauth endpoint
+	 */
+	API_GENERATED_TOKEN
+
+}

--- a/src/test/java/com/researchspace/model/oauth/OAuthTokenTest.java
+++ b/src/test/java/com/researchspace/model/oauth/OAuthTokenTest.java
@@ -8,6 +8,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.stream.Stream;
 
+import org.junit.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -24,23 +25,25 @@ class OAuthTokenTest {
 		anyUser = createAnyUser("any");
 	}
 
-	@ParameterizedTest(name = "{index}: user:{0}, clientId:{1}, accessToken:{2})")
+	@ParameterizedTest(name = "{index}: user:{0}, clientId:{1}, tokenType:{2})")
 	@MethodSource("constructorValidationArguments")
-	void constructorValidationNoNullArgs(User user, String clientId, String hashedToken) {
-		assertIllegalArgumentException(() -> new OAuthToken(user, clientId, hashedToken));
+	void constructorValidationNoNullArgs(User user, String clientId, OAuthTokenType tokenType) {
+		assertIllegalArgumentException(() -> new OAuthToken(user, clientId, tokenType));
 	}
 
+	@Test
 	void expiryTimeInFuture() {
-		assertIllegalArgumentException(() -> new OAuthToken(anyUser, "anId", "token", inthePast()));
-		OAuthToken valid = new OAuthToken(anyUser, "id", "token", inTheFuture());
-		assertEquals("id", valid.getClientId());
+		OAuthToken token = new OAuthToken(anyUser, "id", OAuthTokenType.UI_TOKEN);
+		assertIllegalArgumentException(() -> token.setExpiryTime(inthePast()));
+		token.setExpiryTime(inTheFuture());
+		assertEquals("id", token.getClientId());
 	}
 
 	static Stream<Arguments> constructorValidationArguments() throws Throwable {
-		return Stream.of(Arguments.of(null, "clientid", "hashedToken"),
-				Arguments.of(createAnyUser("any"), "", "hashedToken"),
-				Arguments.of(createAnyUser("any"), null, "hashedToken"),
-				Arguments.of(createAnyUser("any"), "clientId", " "),
+		return Stream.of(Arguments.of(null, "clientid", OAuthTokenType.UI_TOKEN),
+				Arguments.of(createAnyUser("any"), "", OAuthTokenType.UI_TOKEN),
+				Arguments.of(createAnyUser("any"), null, OAuthTokenType.UI_TOKEN),
+				Arguments.of(createAnyUser("any"), "clientId", null),
 				Arguments.of(null, null, null)
 		);
 	}

--- a/src/test/java/com/researchspace/model/record/TestFactory.java
+++ b/src/test/java/com/researchspace/model/record/TestFactory.java
@@ -29,7 +29,6 @@ import com.researchspace.model.Signature;
 import com.researchspace.model.Thumbnail;
 import com.researchspace.model.Thumbnail.SourceType;
 import com.researchspace.model.User;
-import com.researchspace.model.comms.Communication;
 import com.researchspace.model.comms.CommunicationStatus;
 import com.researchspace.model.comms.CommunicationTarget;
 import com.researchspace.model.comms.GroupMessageOrRequest;
@@ -53,6 +52,7 @@ import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.inventory.field.ExtraNumberField;
 import com.researchspace.model.inventory.field.ExtraTextField;
 import com.researchspace.model.oauth.OAuthToken;
+import com.researchspace.model.oauth.OAuthTokenType;
 import com.researchspace.model.oauth.UserConnection;
 import com.researchspace.model.oauth.UserConnectionId;
 import com.researchspace.model.permissions.ConstraintPermissionResolver;
@@ -686,8 +686,8 @@ public class TestFactory {
 	 * @param anyUser
 	 * @return
 	 */
-	public static OAuthToken createOAuthToken (User anyUser) {
-		OAuthToken token =   new OAuthToken(anyUser, "clientId", "hashedAccessToken");
+	public static OAuthToken createOAuthTokenForUI(User anyUser) {
+		OAuthToken token = new OAuthToken(anyUser, "clientId", OAuthTokenType.UI_TOKEN);
 		token.setHashedRefreshToken("refreshToken");
 		return token;
 	}


### PR DESCRIPTION
Main change of this PR is some redesign of `OAuthToken` entity class:
- the `scope` field that was never used (i.e. always set to "all") is now removed
- there are two new fields: 
  a) `created` date field - useful for devops debugging, but will also allow implementing token expiration in the future
  b) `tokenType` enum field - will allow distinguishing tokens created during UI session and intended for internal use, from tokens created through username/password oauth flow and intended for external usage (API clients)
- also minor refactorings to make `OAuthToken` class code shorter

Secondary (minor) change in this PR is adding transient field `authenticatedBy` to `User` entity. The field will be populated during api authorization flow and will store the details about how the user's request was authenticated (api key or internal/external token).