### PR TITLE
add new metadata column for storing ad-hoc chemistry data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>rspace-core-model</artifactId>
+  <artifactId>rspace-core-model-rsdev-695</artifactId>
   <version>2.12.0</version>
   <parent>
     <artifactId>rspace-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,8 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>rspace-core-model-rsdev-695</artifactId>
-  <version>2.12.1</version>
+  <artifactId>rspace-core-model</artifactId>
+  <version>2.12.2</version>
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>

--- a/src/main/java/com/researchspace/model/RSChemElement.java
+++ b/src/main/java/com/researchspace/model/RSChemElement.java
@@ -96,6 +96,10 @@ public class RSChemElement implements Serializable, IFieldLinkableElement {
 	 */
 	private Integer rgroupId;
 
+	@Lob
+	@Column(name = "metadata", columnDefinition = "LONGTEXT")
+	private String metadata;
+
 	/**
 	 * A String describing the format of the chem element
 	 */

--- a/src/main/java/com/researchspace/model/RSChemElement.java
+++ b/src/main/java/com/researchspace/model/RSChemElement.java
@@ -58,7 +58,7 @@ public class RSChemElement implements Serializable, IFieldLinkableElement {
 	@Id
 	@GeneratedValue(strategy = GenerationType.TABLE)
 	private Long id;
-	
+
 	private Long parentId;
 
 	private Long ecatChemFileId;
@@ -96,8 +96,7 @@ public class RSChemElement implements Serializable, IFieldLinkableElement {
 	 */
 	private Integer rgroupId;
 
-	@Lob
-	@Column(name = "metadata", columnDefinition = "LONGTEXT")
+	@Column(columnDefinition="TEXT")
 	private String metadata;
 
 	/**
@@ -116,7 +115,7 @@ public class RSChemElement implements Serializable, IFieldLinkableElement {
 	@ManyToOne
 	@JsonIgnore
 	private Record record;
-	
+
 	@CreationTimestamp
 	@Temporal(TemporalType.TIMESTAMP)
 	@Column(nullable=false, updatable=false)
@@ -132,7 +131,7 @@ public class RSChemElement implements Serializable, IFieldLinkableElement {
 	@ManyToOne
 	@Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)
 	private FileProperty imageFileProperty;
-	
+
 	public RSChemElement() {
 	}
 


### PR DESCRIPTION
Required for the pubchem import to be able to store the pubchem url and cas number.

These could've been added as distinct columns, but wouldn't be required for the vast majority of chemicals. If we find we start using this info for other chemicals, we could always do a migration to a more structured approach.