### PR TITLE
RSDEV-760: minor optimization around ELN record's isShared and isPublished calculations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rspace-core-model</artifactId>
-  <version>2.13.0</version>
+  <version>2.13.1</version>
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>

--- a/src/main/java/com/researchspace/model/record/BaseRecord.java
+++ b/src/main/java/com/researchspace/model/record/BaseRecord.java
@@ -1320,30 +1320,28 @@ public abstract class BaseRecord
 
     @Transient
     public boolean isShared() {
-        Set<String> usersOrGrpsInACL = makeSharedUserNames();
-        usersOrGrpsInACL.remove(ANONYMOUS_USER);
-        // We only expect to see a single username if a record hasn't been shared
-        if (usersOrGrpsInACL.size() > 1) {
-            return true;
+        String lastUser = null;
+        for (ACLElement el : this.getSharingACL().getAclElements()) {
+            if (!ANONYMOUS_USER.equals(el.getUserOrGrpUniqueName())) {
+                if (lastUser != null && !lastUser.equals(el.getUserOrGrpUniqueName())) {
+                    /* We only expect to see a single username if a record hasn't been shared */
+                    return true;
+                }
+                lastUser = el.getUserOrGrpUniqueName();
+            }
         }
-
         return false;
     }
 
-    private Set<String> makeSharedUserNames() {
-        Set<String> usersOrGrpsInACL = new HashSet<>();
-
+    @Transient
+    public boolean isPublished() {
         for (ACLElement el : this.getSharingACL().getAclElements()) {
-            usersOrGrpsInACL.add(el.getUserOrGrpUniqueName());
+            if (ANONYMOUS_USER.equals(el.getUserOrGrpUniqueName())) {
+                return true;
+            }
         }
-        return usersOrGrpsInACL;
+        return false;
     }
-
-        @Transient
-        public boolean isPublished() {
-            Set<String> usersOrGrpsInACL = makeSharedUserNames();
-            return usersOrGrpsInACL.contains(ANONYMOUS_USER);
-        }
 
     /**
      * Boolean test for whether this record is a structured document shared into a notebook.


### PR DESCRIPTION
I've rewritten calculations behind isShared and isPublished methods, to allow short-circuit evaluation rather than operating on complete ACL, which may sometimes be very long. 

I've tried to measure the speed improvement in unit test (using StopWatch class), and to be honest the improvement is minimal. Still, we run shared/published flags calculations every time an ELN record is displayed in Workspace listing, so even 1ms difference is nice.