### PR TITLE
RSDEV-796: block unsafe move actions on BaseRecord level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rspace-core-model-rsdev-796</artifactId>
-  <version>2.14.0</version>
+  <version>2.13.2</version>
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rspace-core-model-rsdev-796</artifactId>
-  <version>2.13.5</version>
+  <version>2.13.6</version>
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rspace-core-model-rsdev-796</artifactId>
-  <version>2.13.4</version>
+  <version>2.13.5</version>
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,8 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>rspace-core-model-rsdev-796</artifactId>
-  <version>2.13.6</version>
+  <artifactId>rspace-core-model</artifactId>
+  <version>2.13.2</version>
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rspace-core-model-rsdev-796</artifactId>
-  <version>2.13.3</version>
+  <version>2.13.4</version>
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rspace-core-model-rsdev-796</artifactId>
-  <version>2.13.2</version>
+  <version>2.13.3</version>
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,8 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>rspace-core-model</artifactId>
-  <version>2.13.1</version>
+  <artifactId>rspace-core-model-rsdev-796</artifactId>
+  <version>2.14.0</version>
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>

--- a/src/main/java/com/researchspace/model/User.java
+++ b/src/main/java/com/researchspace/model/User.java
@@ -1007,7 +1007,8 @@ public class User extends AbstractUserOrGroupImpl
 		if (getRootFolder() == null) {
 			return null;
 		}
-		return getRootFolder().getSystemSubFolderByName(Folder.SHARED_FOLDER_NAME);
+		//return getRootFolder().getSystemSubFolderByName(Folder.SHARED_FOLDER_NAME);
+		return getRootFolder().getSubFolderByName(Folder.SHARED_FOLDER_NAME);
 	}
 
 	public void setRootFolder(Folder rootFolder) {

--- a/src/main/java/com/researchspace/model/User.java
+++ b/src/main/java/com/researchspace/model/User.java
@@ -1007,8 +1007,7 @@ public class User extends AbstractUserOrGroupImpl
 		if (getRootFolder() == null) {
 			return null;
 		}
-		//return getRootFolder().getSystemSubFolderByName(Folder.SHARED_FOLDER_NAME);
-		return getRootFolder().getSubFolderByName(Folder.SHARED_FOLDER_NAME);
+		return getRootFolder().getSystemSubFolderByName(Folder.SHARED_FOLDER_NAME);
 	}
 
 	public void setRootFolder(Folder rootFolder) {

--- a/src/main/java/com/researchspace/model/User.java
+++ b/src/main/java/com/researchspace/model/User.java
@@ -1007,7 +1007,7 @@ public class User extends AbstractUserOrGroupImpl
 		if (getRootFolder() == null) {
 			return null;
 		}
-		return getRootFolder().getSubFolderByName(Folder.SHARED_FOLDER_NAME);
+		return getRootFolder().getSystemSubFolderByName(Folder.SHARED_FOLDER_NAME);
 	}
 
 	public void setRootFolder(Folder rootFolder) {

--- a/src/main/java/com/researchspace/model/record/BaseRecord.java
+++ b/src/main/java/com/researchspace/model/record/BaseRecord.java
@@ -602,7 +602,7 @@ public abstract class BaseRecord
             if (from.isTopLevelSharedFolder()) {
                 return false;
             }
-            if (from.isSharedFolder() && !to.isSharedFolder()) {
+            if (from.isSharedFolder() && !(to.isSharedFolder() || to.isNotebook())) {
                 return false;
             }
             if (!from.isSharedFolder() && to.isSharedFolder()) {

--- a/src/main/java/com/researchspace/model/record/BaseRecord.java
+++ b/src/main/java/com/researchspace/model/record/BaseRecord.java
@@ -605,6 +605,12 @@ public abstract class BaseRecord
             if (from.isSharedFolder() && !to.isSharedFolder()) {
                 return false;
             }
+            if (!from.isSharedFolder() && to.isSharedFolder()) {
+                return false;
+            }
+            if (!from.isSharedFolder() && !from.getOwner().equals(to.getOwner())) {
+                return false; // block move from user's Workspace folder into somebody else's
+            }
         }
 
         boolean removed = from.removeChild(this);

--- a/src/main/java/com/researchspace/model/record/Folder.java
+++ b/src/main/java/com/researchspace/model/record/Folder.java
@@ -590,7 +590,7 @@ public class Folder extends BaseRecord implements TaggableElnRecord {
 		}
 	
 		Folder toAdd = null;
-		toAdd = parent.getSubFolderByName(SHARED_FOLDER_NAME);
+		toAdd = parent.getSystemSubFolderByName(SHARED_FOLDER_NAME);
 		if (toAdd == null) {
 			toAdd = parent;
 		}
@@ -648,6 +648,16 @@ public class Folder extends BaseRecord implements TaggableElnRecord {
 	public Folder getSubFolderByName(String name) {
 		for (BaseRecord child : getChildrens()) {
 			if (child.isFolder() && child.getName().equals(name)) {
+				return (Folder) child;
+			}
+		}
+		return null;
+	}
+
+	@Transient
+	public Folder getSystemSubFolderByName(String name) {
+		for (BaseRecord child : getChildrens()) {
+			if (child.isFolder() && ((Folder) child).isSystemFolder() && child.getName().equals(name)) {
 				return (Folder) child;
 			}
 		}

--- a/src/main/java/com/researchspace/model/record/Folder.java
+++ b/src/main/java/com/researchspace/model/record/Folder.java
@@ -366,7 +366,7 @@ public class Folder extends BaseRecord implements TaggableElnRecord {
 		if (toRemove != null) {
 			boolean removed1 = children.remove(toRemove);
 			boolean removed2 = child.getParents().remove(toRemove);
-			boolean removedOK = removed1 && removed2;
+			boolean removedOK = removed1 || removed2;
 			if (removedOK) {
 				aclPolicy.onRemove(this, child);
 				return true;
@@ -386,14 +386,19 @@ public class Folder extends BaseRecord implements TaggableElnRecord {
 	}
 
 	RecordToFolder findRecordInChildRelations(BaseRecord child) {
-		RecordToFolder toRemove = null;
 		for (RecordToFolder reln : children) {
 			if (reln.getRecord().equals(child)) {
-				toRemove = reln;
-				break;
+				return reln;
 			}
 		}
-		return toRemove;
+		/* 'children' may not have recently shared record, as sharing in some cases skips adding
+		to 'children' array for better performance. Check child's parents in that case. */
+		for (RecordToFolder reln : child.getParents()) {
+			if (reln.getRecord().equals(child)) {
+				return reln;
+			}
+		}
+		return null;
 	}
 
 	/**

--- a/src/main/java/com/researchspace/model/record/Folder.java
+++ b/src/main/java/com/researchspace/model/record/Folder.java
@@ -639,9 +639,13 @@ public class Folder extends BaseRecord implements TaggableElnRecord {
 
 	/**
 	 * Gets an immediate subfolder by name, or <code>null</code> if not found.
-	 * 
+	 *
+	 * @deprecated there may be multiple subfolders with given name, this
+	 * 		method just returns the first one, which may be not what is expected
+	 *
 	 * @param name
 	 */
+	@Deprecated
 	@Transient
 	public Folder getSubFolderByName(String name) {
 		for (BaseRecord child : getChildrens()) {

--- a/src/main/java/com/researchspace/model/record/Folder.java
+++ b/src/main/java/com/researchspace/model/record/Folder.java
@@ -366,7 +366,6 @@ public class Folder extends BaseRecord implements TaggableElnRecord {
 		if (toRemove != null) {
 			boolean removed1 = children.remove(toRemove);
 			boolean removed2 = child.getParents().remove(toRemove);
-			//boolean removedOK = removed1 || removed2;
 			boolean removedOK = removed1 && removed2;
 			if (removedOK) {
 				aclPolicy.onRemove(this, child);
@@ -388,13 +387,6 @@ public class Folder extends BaseRecord implements TaggableElnRecord {
 
 	RecordToFolder findRecordInChildRelations(BaseRecord child) {
 		for (RecordToFolder reln : children) {
-			if (reln.getRecord().equals(child)) {
-				return reln;
-			}
-		}
-		/* 'children' may not have recently shared record, as sharing in some cases skips adding
-		to 'children' array for better performance. Check child's parents in that case. */
-		for (RecordToFolder reln : child.getParents()) {
 			if (reln.getRecord().equals(child)) {
 				return reln;
 			}

--- a/src/main/java/com/researchspace/model/record/Folder.java
+++ b/src/main/java/com/researchspace/model/record/Folder.java
@@ -366,7 +366,8 @@ public class Folder extends BaseRecord implements TaggableElnRecord {
 		if (toRemove != null) {
 			boolean removed1 = children.remove(toRemove);
 			boolean removed2 = child.getParents().remove(toRemove);
-			boolean removedOK = removed1 || removed2;
+			//boolean removedOK = removed1 || removed2;
+			boolean removedOK = removed1 && removed2;
 			if (removedOK) {
 				aclPolicy.onRemove(this, child);
 				return true;

--- a/src/test/java/com/researchspace/model/record/FolderTest.java
+++ b/src/test/java/com/researchspace/model/record/FolderTest.java
@@ -1,5 +1,6 @@
 package com.researchspace.model.record;
 
+import static com.researchspace.model.record.Folder.SHARED_FOLDER_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -128,13 +129,38 @@ public class FolderTest {
 	}
 
 	@Test
-	public void moveToTReurnsFalseIfTargetAlreadyHoldsRecord()
+	public void moveToReturnsFalseIfTargetAlreadyHoldsRecord()
 			throws InterruptedException, IllegalAddChildOperation {
 		makeNestedFolders();
 		Folder old = t3.getParent();
 		assertTrue(t3.move(t3.getParent(), t1, anyuser)); // OK
 		assertFalse(t3.move(old, t1, anyuser)); // not OK, is already in t1
 		assertFalse(t3.move(null, null, null)); // no null args
+	}
+
+	@Test
+	public void moveToReturnsFalseIfMovingSharedFoldersOutOfShared() {
+		Folder workspaceRoot = new Folder();
+		workspaceRoot.addType(RecordType.ROOT);
+		Folder workspaceSubfolder = new Folder();
+
+		Folder sharedFolder = new Folder();
+		sharedFolder.setSystemFolder(true);
+		sharedFolder.setName(SHARED_FOLDER_NAME);
+		Folder sharedGroupFolder = new Folder();
+		sharedGroupFolder.addType(RecordType.SHARED_GROUP_FOLDER_ROOT);
+		Folder sharedGroupSubFolder = new Folder();
+		sharedGroupSubFolder.addType(RecordType.SHARED_FOLDER);
+
+		workspaceRoot.addChild(workspaceSubfolder, anyuser);
+		workspaceRoot.addChild(sharedFolder, anyuser);
+		sharedFolder.addChild(sharedGroupFolder, anyuser);
+		sharedGroupFolder.addChild(sharedGroupSubFolder, anyuser);
+
+		// shared folders of various types shouldn't be movable out of Workspace->Shared hierarchy
+		assertFalse(sharedFolder.move(workspaceRoot, workspaceSubfolder, anyuser));
+		assertFalse(sharedGroupFolder.move(sharedFolder, workspaceSubfolder, anyuser));
+		assertFalse(sharedGroupSubFolder.move(sharedGroupFolder, workspaceSubfolder, anyuser));
 	}
 
 	@Test
@@ -202,7 +228,7 @@ public class FolderTest {
 	@Test
 	public void addToSharedFolder() throws IllegalAddChildOperation {
 		Folder sharedFolder = new Folder();
-		sharedFolder.setName(Folder.SHARED_FOLDER_NAME);
+		sharedFolder.setName(SHARED_FOLDER_NAME);
 		User user = TestFactory.createAnyUser("us");
 		Folder root = TestFactory.createAFolder("root", user);
 		root.addType(RecordType.ROOT);

--- a/src/test/java/com/researchspace/model/record/FolderTest.java
+++ b/src/test/java/com/researchspace/model/record/FolderTest.java
@@ -228,6 +228,7 @@ public class FolderTest {
 	@Test
 	public void addToSharedFolder() throws IllegalAddChildOperation {
 		Folder sharedFolder = new Folder();
+		sharedFolder.setSystemFolder(true);
 		sharedFolder.setName(SHARED_FOLDER_NAME);
 		User user = TestFactory.createAnyUser("us");
 		Folder root = TestFactory.createAFolder("root", user);

--- a/src/test/java/com/researchspace/model/record/NotebookTest.java
+++ b/src/test/java/com/researchspace/model/record/NotebookTest.java
@@ -122,8 +122,8 @@ public class NotebookTest {
 
 	@Test
 	public void moveTo() throws InterruptedException, IllegalAddChildOperation {
-		 makeNestedFolders();
-		 Folder old = nb3.getParent();
+		makeNestedFolders();
+		Folder old = nb3.getParent();
 		assertTrue(nb3.move(nb3.getParent(), folder1, anyuser)); // OK
 		assertFalse(nb3.move(old, folder1, anyuser)); // not OK, is already in t1
 	}

--- a/src/test/java/com/researchspace/model/record/NotebookTest.java
+++ b/src/test/java/com/researchspace/model/record/NotebookTest.java
@@ -98,6 +98,7 @@ public class NotebookTest {
 		assertTrue(n.hasType(RecordType.NOTEBOOK));
 		assertTrue(n.isNotebook());
 	}
+
 	//RSPAC1814
 	@Test
 	public void moveOutOfNotebookRequiresSameOwner() {
@@ -106,7 +107,6 @@ public class NotebookTest {
 		assertTrue(sd.move(notebook, folder1, anyuser));
 		assertEquals(0, notebook.getChildrens().size());
 		assertEquals(1, folder1.getChildrens().size());
-		
 	}
 	
 	@Test


### PR DESCRIPTION
The main part of this PR is a set of additional checks in `BaseRecord.move()`, which are to ensure that moving records between Workspace folder and Shared folder is not possible. Moving between Workspace and Shared (or vice versa) should never be needed, as records appear or disappear in Shared folder through share/unshare actions, not through moving.

The PR also adds a new `BaseRecord.unsafeMove()` method that allows skipping new checks, this is to allow investigation on accidentally moved content that may get reported on production (e.g. SUPPORT-526).

Finally, when investigating the code I found that `User.getSharedFolder()` method is a bit optimistic by returning first found folder named 'Shared' inside root/Workspace folder. In reality user may (hopefully doesn't) create own folders named 'Shared', and so to get the correct Shared folder the 'system' flag should be checked. This is now done by using new `Folder.getSystemSubFolderByName()` method, and I've also marked `Folder.getSubFolderByName()` as `@Deprecated` (it should probably be completely removed, but that's out of the scope for this PR).



