### PR TITLE
RSDEV-446: continue refactoring of Folder.children usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,8 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>rspace-core-model</artifactId>
-  <version>2.15.1</version>
+  <artifactId>rspace-core-model-rsdev-446</artifactId>
+  <version>2.15.2</version>
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>rspace-core-model-rsdev-446</artifactId>
+  <artifactId>rspace-core-model</artifactId>
   <version>2.15.2</version>
   <parent>
     <artifactId>rspace-parent</artifactId>

--- a/src/main/java/com/researchspace/model/User.java
+++ b/src/main/java/com/researchspace/model/User.java
@@ -1002,14 +1002,6 @@ public class User extends AbstractUserOrGroupImpl
 		return rootFolder;
 	}
 
-	@Transient
-	public Folder getSharedFolder() {
-		if (getRootFolder() == null) {
-			return null;
-		}
-		return getRootFolder().getSystemSubFolderByName(Folder.SHARED_FOLDER_NAME);
-	}
-
 	public void setRootFolder(Folder rootFolder) {
 		this.rootFolder = rootFolder;
 	}

--- a/src/main/java/com/researchspace/model/record/Folder.java
+++ b/src/main/java/com/researchspace/model/record/Folder.java
@@ -411,7 +411,7 @@ public class Folder extends BaseRecord implements TaggableElnRecord {
 	/**
 	 * Gets children records / subfolders of this folder.
 	 *
-	 * @deprecated this method loads all children of folder, which may be very inefficient;
+	 * @deprecated the method loads all children of the folder, which may be very inefficient;
 	 * 		rethink if you really need to operate on everything inside the folder, and even if you do,
 	 * 		use direct db query
 	 */
@@ -424,7 +424,7 @@ public class Folder extends BaseRecord implements TaggableElnRecord {
 	/**
 	 * Gets child records filtered by a {@link CollectionFilter}
 	 *
-	 * @deprecated this method iterates over all children of folder, which may be very inefficient;
+	 * @deprecated the method iterates over all children of the folder, which may be very inefficient;
 	  	you should rather use direct db query, with the requested filter
 	 *
 	 * @param rf
@@ -447,7 +447,7 @@ public class Folder extends BaseRecord implements TaggableElnRecord {
 	 * Convenience method to return only subfolders of this folder, ignoring any
 	 * records as children.
 	 *
-	 * @deprecated this method iterates over all children of folder, which may be very inefficient;
+	 * @deprecated the method iterates over all children of the folder, which may be very inefficient;
 	 *  	you should rather retrieve subfolders with direct db query
 	 * @return a non-null {@link Set} of subfolders
 	 */
@@ -549,7 +549,7 @@ public class Folder extends BaseRecord implements TaggableElnRecord {
 	/**
 	 * Gets an immediate child system folder by name, or <code>null</code> if not found.
 	 *
-	 * @deprecated this method iterates over children of folder, which may be very inefficient;
+	 * @deprecated the method iterates over children of the folder, which may be very inefficient;
 	 * 		you should rather retrieve requested folder with direct db query
 	 */
 	@Deprecated

--- a/src/main/java/com/researchspace/model/record/Folder.java
+++ b/src/main/java/com/researchspace/model/record/Folder.java
@@ -382,25 +382,6 @@ public class Folder extends BaseRecord implements TaggableElnRecord {
 	}
 
 	/**
-	 * Boolean test as to whether the relationship between this Folder and the
-	 * argument record is marked as deleted or not.
-	 * 
-	 * @param r
-	 *            A direct child of this folder
-	 * @return <code>true</code> if <code>child</code> is marked as deleted,
-	 *         <code>false</code> otherwise.
-	 */
-	@Transient
-	public boolean isMarkedDeleted(BaseRecord r) {
-		for (RecordToFolder rtf : getChildren()) {
-			if (rtf.getRecord().equals(r)) {
-				return rtf.isRecordInFolderDeleted();
-			}
-		}
-		return false;
-	}
-
-	/**
 	 * Visitor-pattern method that iterates over the folder tree, calling the
 	 * <em>process()</em> method of the supplied
 	 * {@link RecordContainerProcessor} on each record and folder.
@@ -603,24 +584,8 @@ public class Folder extends BaseRecord implements TaggableElnRecord {
 	}
 
 	/**
-	 * Gets an immediate subfolder by name, or <code>null</code> if not found.
-	 *
-	 * @deprecated there may be multiple subfolders with given name, this
-	 * 		method just returns the first one, which may be not what is expected
-	 *
-	 * @param name
+	 * Gets an immediate child system folder by name, or <code>null</code> if not found.
 	 */
-	@Deprecated
-	@Transient
-	public Folder getSubFolderByName(String name) {
-		for (BaseRecord child : getChildrens()) {
-			if (child.isFolder() && child.getName().equals(name)) {
-				return (Folder) child;
-			}
-		}
-		return null;
-	}
-
 	@Transient
 	public Folder getSystemSubFolderByName(String name) {
 		for (BaseRecord child : getChildrens()) {

--- a/src/test/java/com/researchspace/model/record/FolderTest.java
+++ b/src/test/java/com/researchspace/model/record/FolderTest.java
@@ -234,14 +234,8 @@ public class FolderTest {
 		Folder root = TestFactory.createAFolder("root", user);
 		root.addType(RecordType.ROOT);
 		root.addChild(sharedFolder, user);
-		Folder added = root.addRecordToUsersSharedFolder(TestFactory.createAnySD(), user);
+		Folder added = sharedFolder.addChild(TestFactory.createAnySD(), user, true).getFolder();
 		assertEquals(added, sharedFolder);
-
-		// rename shared folder, no longer follows naming convention,adds to
-		// root instead
-		sharedFolder.setName("other");
-		added = root.addRecordToUsersSharedFolder(TestFactory.createAnySD(), user);
-		assertEquals(root, added);
 	}
 
 	@Test


### PR DESCRIPTION
The PR removes some more `Folder` methods that operate on `children` list - some were not used outside of tests, and usage of some other could be relatively easily replaced. Also, `User.getSharedFolder()` method was removed.

There is connected PR for rspace-web: https://github.com/rspace-os/rspace-web/pull/473.

