### PR TITLE
PRT-1060 Moving a linked subsample causes Stoichiometry to fail to load

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rspace-core-model</artifactId>
-  <version>2.21.0</version>
+  <version>2.21.1</version>
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>

--- a/src/main/java/com/researchspace/model/inventory/MovableInventoryRecord.java
+++ b/src/main/java/com/researchspace/model/inventory/MovableInventoryRecord.java
@@ -8,6 +8,8 @@ import javax.persistence.Transient;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.envers.Audited;
 import org.hibernate.envers.RelationTargetAuditMode;
 import org.hibernate.search.annotations.Field;
@@ -30,6 +32,7 @@ public abstract class MovableInventoryRecord extends InventoryRecord {
 	 */
 	@OneToOne(cascade = CascadeType.MERGE)
 	@Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)
+	@NotFound(action = NotFoundAction.IGNORE)
 	public ContainerLocation getParentLocation() {
 		return parentLocation;
 	}


### PR DESCRIPTION
Ticket: https://researchspace.atlassian.net/browse/PRT-1060
AWS Build: https://prt-1060-stoichiometry-moved-subsample-3.researchspace.com
Jenkins Build: https://jenkins.researchspace.com/job/rspace-web/job/prt-1060-stoichiometry-moved-subsample/2/

**Cause**
Stoichiometry entities are audited, so hibernate recreates the Stoichiometry entity as it was in the revision number that’s been embedded in the document. This involves building the relationships Stoichiometry → StoichiometryMolecule → StoichiometryInventoryLink → SubSample → ContainerLocation. However, ContainerLocation isn’t audited, therefore hibernate can’t find the old location when loading the Stoichiometry revision, as it’s been moved, so it throws an exception.

**Fix**
We don’t use ContainerLocation in Stoichiometry, therefore we don’t mind if it doesn’t get loaded. Adding `@NotFound(action = NotFoundAction.IGNORE)` annotation on `rspace-core-model:MoveableInventoryRecord.getParentLocation()` stops the default behaviour of throwing an exception, and instead sets it to null. 

The impact is minimal since `getParentLocation()` could already return null, so checks are in place to handle that. And this bug is limited only to loading old revisions of `MovableInventoryRecord` (or entities connected to them).