### PR TITLE
RSDEV-1023: extending nfs option enums to support s3 connector options

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,9 +2,6 @@
 
 Summary of important or breaking changes.
 
-## 2.21.2 2026-04-29
-- Added S3 client type support to `NfsFileSystem` and `NfsFileSystemInfo` (exposes `S3_BUCKET_NAME` option)
-
 ## 2.21.0 2026-03-31
 - Change `connectedUser` and `connectedGroups` to be a `Set` instead of a `List`
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 Summary of important or breaking changes.
 
+## 2.21.2 2026-04-29
+- Added S3 client type support to `NfsFileSystem` and `NfsFileSystemInfo` (exposes `S3_BUCKET_NAME` option)
+
 ## 2.21.0 2026-03-31
 - Change `connectedUser` and `connectedGroups` to be a `Set` instead of a `List`
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rspace-core-model</artifactId>
-  <version>2.20.1</version>
+  <version>2.20.2</version>
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rspace-core-model</artifactId>
-  <version>2.21.1</version>
+  <version>2.21.2</version>
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>

--- a/src/main/java/com/researchspace/model/netfiles/NfsAuthenticationType.java
+++ b/src/main/java/com/researchspace/model/netfiles/NfsAuthenticationType.java
@@ -13,19 +13,11 @@ public enum NfsAuthenticationType {
 	/**
 	 * public/private key authentication
 	 */
-	PUBKEY;
-	
-	/**
-	 * Get enum object for linked string value
-	 */
-	public static NfsAuthenticationType fromString(String authTypeString) {
-		if ("password".equals(authTypeString)) {
-			return PASSWORD;
-		}
-		if ("pubKey".equals(authTypeString)) {
-			return PUBKEY;
-		}
-		throw new IllegalArgumentException("unrecognised authentication type: " + authTypeString);
-	}
+	PUBKEY,
 
+	/**
+	 * if server-configured authentication should be used
+	 */
+	SERVER
+	
 }

--- a/src/main/java/com/researchspace/model/netfiles/NfsAuthenticationType.java
+++ b/src/main/java/com/researchspace/model/netfiles/NfsAuthenticationType.java
@@ -16,8 +16,8 @@ public enum NfsAuthenticationType {
 	PUBKEY,
 
 	/**
-	 * if server-configured authentication should be used
+	 * if user doesn't need to explicitly authenticate
 	 */
-	SERVER
+	NONE
 	
 }

--- a/src/main/java/com/researchspace/model/netfiles/NfsClientType.java
+++ b/src/main/java/com/researchspace/model/netfiles/NfsClientType.java
@@ -28,6 +28,6 @@ public enum NfsClientType {
 	/**
 	 * AWS S3 client type
 	 */
-	AWS_S3;
+	S3;
 	
 }

--- a/src/main/java/com/researchspace/model/netfiles/NfsClientType.java
+++ b/src/main/java/com/researchspace/model/netfiles/NfsClientType.java
@@ -23,22 +23,11 @@ public enum NfsClientType {
 	/**
 	 * iRODS client type
 	 */
-	IRODS;
-	
-	/**
-	 * Get enum object for linked string value
-	 */
-	public static NfsClientType fromString(String clientTypeString) {
-		if ("samba".equalsIgnoreCase(clientTypeString)) {
-			return SAMBA;
-		}
-		if ("smbj".equalsIgnoreCase(clientTypeString)) {
-			return SMBJ;
-		}
-		if ("sftp".equalsIgnoreCase(clientTypeString)) {
-			return SFTP;
-		}
-		throw new IllegalArgumentException("unrecognised client type: " + clientTypeString);
-	}
+	IRODS,
 
+	/**
+	 * AWS S3 client type
+	 */
+	AWS_S3;
+	
 }

--- a/src/main/java/com/researchspace/model/netfiles/NfsFileSystemInfo.java
+++ b/src/main/java/com/researchspace/model/netfiles/NfsFileSystemInfo.java
@@ -40,6 +40,9 @@ public class NfsFileSystemInfo implements Serializable {
 		if ("SMBJ".equals(clientType)) {
 			options.put(NfsFileSystemOption.SAMBA_SHARE_NAME.toString(), 
 					nfsFileSystem.getClientOption(NfsFileSystemOption.SAMBA_SHARE_NAME));
+		} else if ("S3".equals(clientType)) {
+			options.put(NfsFileSystemOption.S3_BUCKET_NAME.toString(),
+					nfsFileSystem.getClientOption(NfsFileSystemOption.S3_BUCKET_NAME));
 		} else if (nfsFileSystem.fileSystemRequiresUserRootDirs()) {
 			options.put(NfsFileSystemOption.USER_DIRS_REQUIRED.toString(),
 					nfsFileSystem.getClientOption(NfsFileSystemOption.USER_DIRS_REQUIRED));

--- a/src/main/java/com/researchspace/model/netfiles/NfsFileSystemInfo.java
+++ b/src/main/java/com/researchspace/model/netfiles/NfsFileSystemInfo.java
@@ -34,13 +34,14 @@ public class NfsFileSystemInfo implements Serializable {
 		id = nfsFileSystem.getId();
 		name = nfsFileSystem.getName();
 		url = nfsFileSystem.getUrl();
-		clientType = nfsFileSystem.getClientType().toString();
-		authType = nfsFileSystem.getAuthType().toString();
+		NfsClientType type = nfsFileSystem.getClientType();
+		clientType = type.name();
+		authType = nfsFileSystem.getAuthType().name();
 
-		if ("SMBJ".equals(clientType)) {
+		if (NfsClientType.SMBJ == type) {
 			options.put(NfsFileSystemOption.SAMBA_SHARE_NAME.toString(), 
 					nfsFileSystem.getClientOption(NfsFileSystemOption.SAMBA_SHARE_NAME));
-		} else if ("S3".equals(clientType)) {
+		} else if (NfsClientType.S3 == type) {
 			options.put(NfsFileSystemOption.S3_BUCKET_NAME.toString(),
 					nfsFileSystem.getClientOption(NfsFileSystemOption.S3_BUCKET_NAME));
 		} else if (nfsFileSystem.fileSystemRequiresUserRootDirs()) {

--- a/src/main/java/com/researchspace/model/netfiles/NfsFileSystemOption.java
+++ b/src/main/java/com/researchspace/model/netfiles/NfsFileSystemOption.java
@@ -54,4 +54,14 @@ public enum NfsFileSystemOption {
 	 */
 	IRODS_CSNEG,
 
+	/**
+	 * AWS S3 region
+	 */
+	S3_REGION,
+
+	/**
+	 * Name of the AWS S3 bucket
+	 */
+	S3_BUCKET_NAME
+
 }

--- a/src/main/java/com/researchspace/model/netfiles/NfsFileSystemOption.java
+++ b/src/main/java/com/researchspace/model/netfiles/NfsFileSystemOption.java
@@ -1,7 +1,7 @@
 package com.researchspace.model.netfiles;
 
 /**
- * Enum representing types of values that can be put into NfsFileSystem.clientDetails field.
+ * Enum representing types of values that can be put into NfsFileSystem.clientOptions map.
  */
 public enum NfsFileSystemOption {
 	

--- a/src/main/java/com/researchspace/model/netfiles/NfsFileSystemOption.java
+++ b/src/main/java/com/researchspace/model/netfiles/NfsFileSystemOption.java
@@ -62,6 +62,11 @@ public enum NfsFileSystemOption {
 	/**
 	 * Name of the AWS S3 bucket
 	 */
-	S3_BUCKET_NAME
+	S3_BUCKET_NAME,
+
+	/**
+	 * Whether S3 client should support pathStyleAccessEnabled option (true/false)
+	 */
+	S3_PATH_STYLE_ACCESS_ENABLED
 
 }

--- a/src/main/java/com/researchspace/model/netfiles/NfsFileSystemOption.java
+++ b/src/main/java/com/researchspace/model/netfiles/NfsFileSystemOption.java
@@ -1,7 +1,7 @@
 package com.researchspace.model.netfiles;
 
 /**
- * Enum representing types of values that can be put into NfsFileSystem.clientOptions map.
+ * Enum representing option keys used in NfsFileSystem options maps.
  */
 public enum NfsFileSystemOption {
 	

--- a/src/test/java/com/researchspace/model/netfiles/NfsFileSystemInfoTest.java
+++ b/src/test/java/com/researchspace/model/netfiles/NfsFileSystemInfoTest.java
@@ -28,6 +28,18 @@ public class NfsFileSystemInfoTest{
 	}
 
 	@Test
+	public void testCopyConstructorS3IncludesBucketName() {
+		String testClientOptionsString = "S3_BUCKET_NAME=my-test-bucket";
+		NfsFileSystem fileSystem = new NfsFileSystem();
+		fileSystem.setClientOptions(testClientOptionsString);
+		fileSystem.setClientType(NfsClientType.S3);
+		fileSystem.setAuthType(NfsAuthenticationType.PASSWORD);
+		NfsFileSystemInfo testee = new NfsFileSystemInfo(fileSystem);
+		assertEquals("my-test-bucket", testee.getOptions().get("S3_BUCKET_NAME"));
+		assertEquals("S3", testee.getClientType());
+	}
+
+	@Test
 	public void testCopyConstructorUserDoesNotRequiresRootDirs() {
 
 		NfsFileSystem fileSystem = new NfsFileSystem();


### PR DESCRIPTION
PR extends `NfsAuthenticationType` / `NfsClientType` enums with options for S3 connector. Exposes bucket name in NfsFileSystemInfo options, so front-end can display it.

Also removes `fromString` methods that were outdated anyway (e.g. didn't handle irods connector) (usage is removed in connected PR for `rspace-web` branch).