### PR TITLE
RSDEV-1131-Inventory-link-related-items: add new table for Inventory …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,4 @@ shell.nix
 .envrc
 .nix-mvn-settings.xml
 .nix-mvn-toolchains.xml
-
 .claude/

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rspace-core-model</artifactId>
-  <version>RSDEV-1131-Inventory-link-related-items</version>
+  <version>2.27.0</version>
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rspace-core-model</artifactId>
-  <version>2.27.0</version>
+  <version>RSDEV-1131-Inventory-link-related-items</version>
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rspace-core-model</artifactId>
-  <version>2.26.1</version>
+  <version>2.27.0</version>
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>

--- a/src/main/java/com/researchspace/model/field/FieldType.java
+++ b/src/main/java/com/researchspace/model/field/FieldType.java
@@ -9,7 +9,7 @@ public enum FieldType {
 
 	NUMBER("Number"), STRING("String"), TEXT("Text"), RADIO("Radio"),
 	CHOICE("Choice"), DATE("Date"), TIME("Time"), REFERENCE("Reference"), ATTACHMENT("Attachment"),
-	URI("Uri"), IDENTIFIER("Identifier");
+	URI("Uri"), IDENTIFIER("Identifier"), LINK("Link");
 
 	private String type;
 	public static final String NUMBER_TYPE = "Number";
@@ -23,6 +23,7 @@ public enum FieldType {
 	public static final String ATTACHMENT_TYPE = "Attachment";
 	public static final String URI_TYPE = "Uri";
 	public static final String IDENTIFIER_TYPE = "Identifier";
+	public static final String LINK_TYPE = "Link";
 
 	/**
 	 * Gets the field type for an input String or <code>null</code> if the argument
@@ -59,6 +60,8 @@ public enum FieldType {
 			return URI;
 		case IDENTIFIER_TYPE:
 			return IDENTIFIER;
+		case LINK_TYPE:
+			return LINK;
 		default:
 			return null;
 		}

--- a/src/main/java/com/researchspace/model/inventory/Sample.java
+++ b/src/main/java/com/researchspace/model/inventory/Sample.java
@@ -748,12 +748,14 @@ public class Sample extends InventoryRecord implements Serializable, UniquelyIde
       if (!getFieldByTemplateFieldId(templateField.getId()).isPresent()) {
         InventoryEntityField addedField = copyAndAddSampleField(templateField);
         /*
-         * Fields added by update-to-latest-template-version start with no value. Clear via setData,
-         * not setFieldData, so we skip mandatory validation here: an existing sample cannot supply a
-         * value during a bulk template update, so a newly added mandatory field (e.g. a mandatory
-         * Link) is allowed to start empty and is enforced on the next per-sample edit/save.
+         * Fields added by update-to-latest-template-version start with no value. clearValue() drops
+         * the value without validation (unlike setFieldData), so we skip mandatory validation here:
+         * an existing sample cannot supply a value during a bulk template update, so a newly added
+         * mandatory field (e.g. a mandatory Link) is allowed to start empty and is enforced on the
+         * next per-sample edit/save. clearValue() also clears association-backed values such as a
+         * link field's target, which the copy would otherwise inherit from the template field.
          */
-        addedField.setData(null);
+        addedField.clearValue();
         sampleUpdated = true;
       }
     }

--- a/src/main/java/com/researchspace/model/inventory/Sample.java
+++ b/src/main/java/com/researchspace/model/inventory/Sample.java
@@ -747,8 +747,13 @@ public class Sample extends InventoryRecord implements Serializable, UniquelyIde
     for (InventoryEntityField templateField : getSTemplate().getActiveFields()) {
       if (!getFieldByTemplateFieldId(templateField.getId()).isPresent()) {
         InventoryEntityField addedField = copyAndAddSampleField(templateField);
-        /* fields added through update to latest template version shouldn't have pre-set value */
-        addedField.setFieldData(null);
+        /*
+         * Fields added by update-to-latest-template-version start with no value. Clear via setData,
+         * not setFieldData, so we skip mandatory validation here: an existing sample cannot supply a
+         * value during a bulk template update, so a newly added mandatory field (e.g. a mandatory
+         * Link) is allowed to start empty and is enforced on the next per-sample edit/save.
+         */
+        addedField.setData(null);
         sampleUpdated = true;
       }
     }

--- a/src/main/java/com/researchspace/model/inventory/field/ExtraLinkField.java
+++ b/src/main/java/com/researchspace/model/inventory/field/ExtraLinkField.java
@@ -1,0 +1,55 @@
+package com.researchspace.model.inventory.field;
+
+import javax.persistence.CascadeType;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Transient;
+
+import org.hibernate.envers.Audited;
+
+import com.researchspace.model.field.FieldType;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Audited
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@DiscriminatorValue("link")
+public class ExtraLinkField extends ExtraField {
+
+	private static final long serialVersionUID = 1L;
+	private static final String DEFAULT_NAME = "Link";
+
+	@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+	@JoinColumn(name = "link_id", unique = true)
+	private InventoryLink link;
+
+	public ExtraLinkField() {
+		setName(DEFAULT_NAME);
+	}
+
+	@Transient
+	@Override
+	public FieldType getType() {
+		return FieldType.LINK;
+	}
+
+	@Override
+	public String validateNewData(String data) {
+		return null;
+	}
+
+	@Override
+	public ExtraLinkField shallowCopy() {
+		ExtraLinkField copy = new ExtraLinkField();
+		copyProperties(copy);
+		return copy;
+	}
+
+}

--- a/src/main/java/com/researchspace/model/inventory/field/ExtraLinkField.java
+++ b/src/main/java/com/researchspace/model/inventory/field/ExtraLinkField.java
@@ -21,6 +21,9 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = true)
 @DiscriminatorValue("link")
+/**
+ * Represents an extra field of type 'link' in inventory items. Links to another InventoryItem.
+ */
 public class ExtraLinkField extends ExtraField {
 
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/com/researchspace/model/inventory/field/ExtraLinkField.java
+++ b/src/main/java/com/researchspace/model/inventory/field/ExtraLinkField.java
@@ -12,12 +12,10 @@ import org.hibernate.envers.Audited;
 import com.researchspace.model.field.FieldType;
 
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.Setter;
 
 @Entity
 @Audited
-@Getter
 @Setter
 @EqualsAndHashCode(callSuper = true)
 @DiscriminatorValue("link")
@@ -29,12 +27,20 @@ public class ExtraLinkField extends ExtraField {
 	private static final long serialVersionUID = 1L;
 	private static final String DEFAULT_NAME = "Link";
 
-	@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
-	@JoinColumn(name = "link_id", unique = true)
+	// Annotations placed on getter (not field) because the ExtraField hierarchy
+	// uses PROPERTY access (@Id is on getId()). With field-level annotations
+	// Hibernate ignores @JoinColumn and falls back to the property name as the
+	// column name (yielding `link` instead of `link_id`).
 	private InventoryLink link;
 
 	public ExtraLinkField() {
 		setName(DEFAULT_NAME);
+	}
+
+	@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+	@JoinColumn(name = "link_id", unique = true)
+	public InventoryLink getLink() {
+		return link;
 	}
 
 	@Transient

--- a/src/main/java/com/researchspace/model/inventory/field/ExtraLinkField.java
+++ b/src/main/java/com/researchspace/model/inventory/field/ExtraLinkField.java
@@ -14,14 +14,14 @@ import com.researchspace.model.field.FieldType;
 import lombok.EqualsAndHashCode;
 import lombok.Setter;
 
+/**
+ * Represents an extra field of type 'link' in inventory items. Links to another InventoryItem.
+ */
 @Entity
 @Audited
 @Setter
 @EqualsAndHashCode(callSuper = true)
 @DiscriminatorValue("link")
-/**
- * Represents an extra field of type 'link' in inventory items. Links to another InventoryItem.
- */
 public class ExtraLinkField extends ExtraField {
 
 	private static final long serialVersionUID = 1L;
@@ -58,6 +58,9 @@ public class ExtraLinkField extends ExtraField {
 	public ExtraLinkField shallowCopy() {
 		ExtraLinkField copy = new ExtraLinkField();
 		copyProperties(copy);
+		if (link != null) {
+			copy.setLink(link.shallowCopy());
+		}
 		return copy;
 	}
 

--- a/src/main/java/com/researchspace/model/inventory/field/InventoryEntityField.java
+++ b/src/main/java/com/researchspace/model/inventory/field/InventoryEntityField.java
@@ -110,6 +110,8 @@ public abstract class InventoryEntityField implements Serializable, ValidatingFi
         return new InventoryUriField();
       case FieldType.IDENTIFIER_TYPE:
         return new InventoryIdentifierField();
+      case FieldType.LINK_TYPE:
+        return new InventoryLinkField();
       default:
         throw new IllegalArgumentException(String.format("Unsupported field type %s", fieldType));
     }

--- a/src/main/java/com/researchspace/model/inventory/field/InventoryEntityField.java
+++ b/src/main/java/com/researchspace/model/inventory/field/InventoryEntityField.java
@@ -288,6 +288,20 @@ public abstract class InventoryEntityField implements Serializable, ValidatingFi
     return StringUtils.isNotBlank(fieldData);
   }
 
+  /**
+   * Whether a field that newly becomes mandatory during an "update samples/instruments to latest
+   * template version" run must already hold a value, failing {@link
+   * #updateToLatestTemplateDefinition()} when it does not. True for fields whose value lives in the
+   * data column. {@link InventoryLinkField} overrides this to false: a mandatory link is
+   * legitimately left unfilled by such a bulk update and is populated by a later, separate link
+   * update, so it must not abort the sync (the link target is still enforced when the sample is
+   * actually edited and saved).
+   */
+  @Transient
+  protected boolean requiresValueWhenBecomingMandatoryOnTemplateUpdate() {
+    return true;
+  }
+
   public abstract InventoryEntityField shallowCopy();
 
   @Transient
@@ -364,7 +378,8 @@ public abstract class InventoryEntityField implements Serializable, ValidatingFi
     }
     if (isMandatory() != templateField.isMandatory()) {
       setMandatory(templateField.isMandatory());
-      if (!isValidValueForMandatoryField(getFieldData())) {
+      if (requiresValueWhenBecomingMandatoryOnTemplateUpdate()
+          && !isValidValueForMandatoryField(getFieldData())) {
         throw new IllegalStateException("Field [" + getName() + "] is empty, but "
             + "is mandatory in latest template field definition");
       }

--- a/src/main/java/com/researchspace/model/inventory/field/InventoryEntityField.java
+++ b/src/main/java/com/researchspace/model/inventory/field/InventoryEntityField.java
@@ -201,6 +201,16 @@ public abstract class InventoryEntityField implements Serializable, ValidatingFi
   }
 
   /**
+   * Clears this field's value without running validation, used when a field is added to an existing
+   * sample during a template-version update and must start empty. The default clears the shared
+   * {@code data} column; field types that hold their value in an association (e.g.
+   * {@link InventoryLinkField}) override this to clear that association too.
+   */
+  public void clearValue() {
+    setData(null);
+  }
+
+  /**
    * Boolean flag to check if field supports storing data as list of options, e.g. as radio or
    * choice fields does.
    */

--- a/src/main/java/com/researchspace/model/inventory/field/InventoryLink.java
+++ b/src/main/java/com/researchspace/model/inventory/field/InventoryLink.java
@@ -83,9 +83,9 @@ public class InventoryLink implements Serializable {
 	}
 
 	/**
-	 * Creates a new, unpersisted copy of this link carrying the same target identity, version pin and
-	 * relation type. The copy has a null id and no timestamps (those are set on persist), so it can be
-	 * attached to a copied field without sharing this managed instance.
+	 * Creates a new, unpersisted copy of this link carrying the same target identity, version pin,
+	 * relation type and deletion state. The copy has a null id and no timestamps (those are set on
+	 * persist), so it can be attached to a copied field without sharing this managed instance.
 	 */
 	public InventoryLink shallowCopy() {
 		InventoryLink copy = new InventoryLink();
@@ -95,6 +95,7 @@ public class InventoryLink implements Serializable {
 		copy.setVersionPin(versionPin);
 		copy.setTargetRevisionId(targetRevisionId);
 		copy.setRelationType(relationType);
+		copy.setDeleted(deleted);
 		return copy;
 	}
 

--- a/src/main/java/com/researchspace/model/inventory/field/InventoryLink.java
+++ b/src/main/java/com/researchspace/model/inventory/field/InventoryLink.java
@@ -1,0 +1,76 @@
+package com.researchspace.model.inventory.field;
+
+import java.io.Serializable;
+import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
+
+import org.hibernate.envers.Audited;
+
+import com.researchspace.model.core.GlobalIdPrefix;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Audited
+@Getter
+@Setter
+@EqualsAndHashCode(of = {"id"})
+public class InventoryLink implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "target_globalid", nullable = false, length = 64)
+	private String targetGlobalId;
+
+	@Column(name = "target_prefix", nullable = false, length = 8)
+	@Enumerated(EnumType.STRING)
+	private GlobalIdPrefix targetPrefix;
+
+	@Column(name = "target_db_id", nullable = false)
+	private Long targetDbId;
+
+	@Column(name = "version_pin")
+	private Long versionPin;
+
+	@Column(name = "relation_type", nullable = false, length = 64)
+	private String relationType;
+
+	@Column(name = "created_at", nullable = false)
+	private Date createdAt;
+
+	@Column(name = "modified_at", nullable = false)
+	private Date modifiedAt;
+
+	@Column(nullable = false)
+	private boolean deleted;
+
+	@PrePersist
+	void prePersist() {
+		Date now = new Date();
+		if (createdAt == null) {
+			createdAt = now;
+		}
+		modifiedAt = now;
+	}
+
+	@PreUpdate
+	void preUpdate() {
+		modifiedAt = new Date();
+	}
+
+}

--- a/src/main/java/com/researchspace/model/inventory/field/InventoryLink.java
+++ b/src/main/java/com/researchspace/model/inventory/field/InventoryLink.java
@@ -47,6 +47,15 @@ public class InventoryLink implements Serializable {
 	@Column(name = "version_pin")
 	private Long versionPin;
 
+	/**
+	 * The Envers revision (REV) this link's pin resolved to, captured at pin time. Null means the
+	 * link is "latest" and resolves dynamically to the newest revision in the target's audit table.
+	 * Paired with {@link #versionPin}: versionPin is the user-facing version for display, this is the
+	 * exact audit-row key used to load the snapshot.
+	 */
+	@Column(name = "target_revision_id")
+	private Long targetRevisionId;
+
 	@Column(name = "relation_type", nullable = false, length = 64)
 	private String relationType;
 

--- a/src/main/java/com/researchspace/model/inventory/field/InventoryLink.java
+++ b/src/main/java/com/researchspace/model/inventory/field/InventoryLink.java
@@ -12,6 +12,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 
 import org.hibernate.envers.Audited;
 
@@ -60,9 +62,11 @@ public class InventoryLink implements Serializable {
 	private String relationType;
 
 	@Column(name = "created_at", nullable = false)
+	@Temporal(TemporalType.TIMESTAMP)
 	private Date createdAt;
 
 	@Column(name = "modified_at", nullable = false)
+	@Temporal(TemporalType.TIMESTAMP)
 	private Date modifiedAt;
 
 	@Column(nullable = false)

--- a/src/main/java/com/researchspace/model/inventory/field/InventoryLink.java
+++ b/src/main/java/com/researchspace/model/inventory/field/InventoryLink.java
@@ -82,4 +82,20 @@ public class InventoryLink implements Serializable {
 		modifiedAt = new Date();
 	}
 
+	/**
+	 * Creates a new, unpersisted copy of this link carrying the same target identity, version pin and
+	 * relation type. The copy has a null id and no timestamps (those are set on persist), so it can be
+	 * attached to a copied field without sharing this managed instance.
+	 */
+	public InventoryLink shallowCopy() {
+		InventoryLink copy = new InventoryLink();
+		copy.setTargetGlobalId(targetGlobalId);
+		copy.setTargetPrefix(targetPrefix);
+		copy.setTargetDbId(targetDbId);
+		copy.setVersionPin(versionPin);
+		copy.setTargetRevisionId(targetRevisionId);
+		copy.setRelationType(relationType);
+		return copy;
+	}
+
 }

--- a/src/main/java/com/researchspace/model/inventory/field/InventoryLinkField.java
+++ b/src/main/java/com/researchspace/model/inventory/field/InventoryLinkField.java
@@ -70,6 +70,13 @@ public class InventoryLinkField extends InventoryEntityField {
         && StringUtils.isNotBlank(link.getRelationType());
   }
 
+  /** Also clears the link association, where this field type holds its value (not the data column). */
+  @Override
+  public void clearValue() {
+    super.clearValue();
+    setLink(null);
+  }
+
   @Override
   public InventoryLinkField shallowCopy() {
     InventoryLinkField copy = new InventoryLinkField();

--- a/src/main/java/com/researchspace/model/inventory/field/InventoryLinkField.java
+++ b/src/main/java/com/researchspace/model/inventory/field/InventoryLinkField.java
@@ -66,25 +66,12 @@ public class InventoryLinkField extends InventoryEntityField {
     InventoryLinkField copy = new InventoryLinkField();
     copy.setAllowedRelationTypes(getAllowedRelationTypes());
     if (link != null) {
-      copy.setLink(copyLink(link));
+      // shallowCopy() deep-copies into a brand-new unsaved row (no id, timestamps set on persist),
+      // so a sample instantiated from a template never shares the template field's link row. Both
+      // clone paths delegate here so they cannot diverge (e.g. on the deleted flag).
+      copy.setLink(link.shallowCopy());
     }
     copyFields(copy);
-    return copy;
-  }
-
-  /**
-   * Deep-copies the link into a brand-new unsaved row (no id, timestamps set on persist), so a
-   * sample instantiated from a template never shares the template field's link row.
-   */
-  private static InventoryLink copyLink(InventoryLink src) {
-    InventoryLink copy = new InventoryLink();
-    copy.setTargetGlobalId(src.getTargetGlobalId());
-    copy.setTargetPrefix(src.getTargetPrefix());
-    copy.setTargetDbId(src.getTargetDbId());
-    copy.setVersionPin(src.getVersionPin());
-    copy.setTargetRevisionId(src.getTargetRevisionId());
-    copy.setRelationType(src.getRelationType());
-    copy.setDeleted(src.isDeleted());
     return copy;
   }
 }

--- a/src/main/java/com/researchspace/model/inventory/field/InventoryLinkField.java
+++ b/src/main/java/com/researchspace/model/inventory/field/InventoryLinkField.java
@@ -1,0 +1,90 @@
+package com.researchspace.model.inventory.field;
+
+import com.researchspace.model.field.FieldType;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Transient;
+import lombok.Setter;
+import org.hibernate.envers.Audited;
+
+/**
+ * A structured Sample template field of type 'link'. It holds a single optional {@link
+ * InventoryLink} value (one target + relation + optional version pin) and a pipe-delimited whitelist
+ * of permitted DataCite relation types. A null/empty whitelist means all relation types are allowed.
+ *
+ * <p>Distinct from {@link ExtraLinkField}, which is the record-level extra-field link; this is part
+ * of the {@link InventoryEntityField} single-table hierarchy used to define template fields.
+ */
+@Entity
+@Audited
+@DiscriminatorValue("link")
+@Setter
+public class InventoryLinkField extends InventoryEntityField {
+
+  private static final long serialVersionUID = 1L;
+
+  private InventoryLink link;
+  private String allowedRelationTypes;
+
+  public InventoryLinkField() {
+    super(FieldType.LINK, "");
+  }
+
+  /*
+   * Annotations are placed on the getter (not the field) because the InventoryEntityField hierarchy
+   * uses PROPERTY access (@Id is on getId()). With field-level annotations Hibernate ignores
+   * @JoinColumn and falls back to the property name as the column name. Mirrors ExtraLinkField.
+   */
+  @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+  @JoinColumn(name = "link_id", unique = true)
+  public InventoryLink getLink() {
+    return link;
+  }
+
+  /**
+   * Pipe-delimited whitelist of permitted DataCite relation types; null or empty means all relation
+   * types are allowed.
+   */
+  @Column(name = "allowed_relation_types", length = 1024)
+  public String getAllowedRelationTypes() {
+    return allowedRelationTypes;
+  }
+
+  /** A mandatory link field requires a populated link target, not data-column content. */
+  @Override
+  @Transient
+  public boolean isValidValueForMandatoryField(String fieldData) {
+    return link != null && link.getTargetGlobalId() != null;
+  }
+
+  @Override
+  public InventoryLinkField shallowCopy() {
+    InventoryLinkField copy = new InventoryLinkField();
+    copy.setAllowedRelationTypes(getAllowedRelationTypes());
+    if (link != null) {
+      copy.setLink(copyLink(link));
+    }
+    copyFields(copy);
+    return copy;
+  }
+
+  /**
+   * Deep-copies the link into a brand-new unsaved row (no id, timestamps set on persist), so a
+   * sample instantiated from a template never shares the template field's link row.
+   */
+  private static InventoryLink copyLink(InventoryLink src) {
+    InventoryLink copy = new InventoryLink();
+    copy.setTargetGlobalId(src.getTargetGlobalId());
+    copy.setTargetPrefix(src.getTargetPrefix());
+    copy.setTargetDbId(src.getTargetDbId());
+    copy.setVersionPin(src.getVersionPin());
+    copy.setTargetRevisionId(src.getTargetRevisionId());
+    copy.setRelationType(src.getRelationType());
+    copy.setDeleted(src.isDeleted());
+    return copy;
+  }
+}

--- a/src/main/java/com/researchspace/model/inventory/field/InventoryLinkField.java
+++ b/src/main/java/com/researchspace/model/inventory/field/InventoryLinkField.java
@@ -70,6 +70,19 @@ public class InventoryLinkField extends InventoryEntityField {
         && StringUtils.isNotBlank(link.getRelationType());
   }
 
+  /**
+   * A link is legitimately left unfilled when existing samples are synced to a template version that
+   * newly marks the link mandatory; it is populated by a later, separate link update (where {@link
+   * #isValidValueForMandatoryField} does enforce a real target + relation type). So an empty
+   * mandatory link must not abort the bulk "update samples to latest template version" run, unlike a
+   * data-column field, which would still require a value.
+   */
+  @Override
+  @Transient
+  protected boolean requiresValueWhenBecomingMandatoryOnTemplateUpdate() {
+    return false;
+  }
+
   /** Also clears the link association, where this field type holds its value (not the data column). */
   @Override
   public void clearValue() {

--- a/src/main/java/com/researchspace/model/inventory/field/InventoryLinkField.java
+++ b/src/main/java/com/researchspace/model/inventory/field/InventoryLinkField.java
@@ -9,6 +9,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.Transient;
 import lombok.Setter;
+import org.apache.commons.lang.StringUtils;
 import org.hibernate.envers.Audited;
 
 /**
@@ -54,11 +55,19 @@ public class InventoryLinkField extends InventoryEntityField {
     return allowedRelationTypes;
   }
 
-  /** A mandatory link field requires a populated link target, not data-column content. */
+  /**
+   * A mandatory link field requires a populated link target and relation type, not data-column
+   * content. Both are checked with a blank (null/empty/whitespace) test: targetGlobalId because a
+   * blank target is not a real reference, and relationType because it is mapped NOT NULL on {@link
+   * InventoryLink}. Without these checks a blank value passes validation and then fails at flush
+   * with a low-level DB constraint violation rather than a clear validation message.
+   */
   @Override
   @Transient
   public boolean isValidValueForMandatoryField(String fieldData) {
-    return link != null && link.getTargetGlobalId() != null;
+    return link != null
+        && StringUtils.isNotBlank(link.getTargetGlobalId())
+        && StringUtils.isNotBlank(link.getRelationType());
   }
 
   @Override

--- a/src/main/java/com/researchspace/model/record/RecordFactory.java
+++ b/src/main/java/com/researchspace/model/record/RecordFactory.java
@@ -33,6 +33,7 @@ import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.inventory.SubSampleName;
 import com.researchspace.model.inventory.field.ExtraField;
+import com.researchspace.model.inventory.field.ExtraLinkField;
 import com.researchspace.model.inventory.field.ExtraNumberField;
 import com.researchspace.model.inventory.field.ExtraTextField;
 import com.researchspace.model.inventory.field.InventoryAttachmentField;
@@ -538,6 +539,9 @@ public class RecordFactory implements IRecordFactory {
     }
     if (FieldType.NUMBER.equals(type)) {
       return new ExtraNumberField();
+    }
+    if (FieldType.LINK.equals(type)) {
+      return new ExtraLinkField();
     }
     throw new IllegalArgumentException(
         "asked for extra field of unsupported type: " + type.toString());

--- a/src/test/java/com/researchspace/model/inventory/field/ExtraLinkFieldTest.java
+++ b/src/test/java/com/researchspace/model/inventory/field/ExtraLinkFieldTest.java
@@ -1,0 +1,66 @@
+package com.researchspace.model.inventory.field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.field.FieldType;
+
+class ExtraLinkFieldTest {
+
+	@Test
+	void getTypeReturnsLink() {
+		ExtraLinkField field = new ExtraLinkField();
+		assertEquals(FieldType.LINK, field.getType());
+	}
+
+	@Test
+	void validateNewDataAcceptsAnyString() {
+		ExtraLinkField field = new ExtraLinkField();
+		assertNull(field.validateNewData(""));
+		assertNull(field.validateNewData("anything"));
+		assertNull(field.validateNewData(null));
+	}
+
+	@Test
+	void shallowCopyProducesIndependentInstanceWithSamePayload() {
+		ExtraLinkField original = new ExtraLinkField();
+		original.setName("related items");
+		original.setData("SA123");
+		original.setId(42L);
+
+		InventoryLink link = new InventoryLink();
+		link.setTargetGlobalId("SA123");
+		link.setTargetPrefix(GlobalIdPrefix.SA);
+		link.setTargetDbId(123L);
+		link.setRelationType("IsCalibratedBy");
+		original.setLink(link);
+
+		ExtraLinkField copy = original.shallowCopy();
+
+		assertNotSame(original, copy);
+		assertNull(copy.getId());
+		assertEquals(original.getName(), copy.getName());
+		assertEquals(original.getData(), copy.getData());
+		assertFalse(copy.isDeleted());
+	}
+
+	@Test
+	void linkAssociationRoundTrips() {
+		ExtraLinkField field = new ExtraLinkField();
+		InventoryLink link = new InventoryLink();
+		link.setTargetGlobalId("SA99");
+		link.setRelationType("References");
+		field.setLink(link);
+
+		assertNotNull(field.getLink());
+		assertEquals("SA99", field.getLink().getTargetGlobalId());
+		assertEquals("References", field.getLink().getRelationType());
+	}
+
+}

--- a/src/test/java/com/researchspace/model/inventory/field/ExtraLinkFieldTest.java
+++ b/src/test/java/com/researchspace/model/inventory/field/ExtraLinkFieldTest.java
@@ -51,6 +51,38 @@ class ExtraLinkFieldTest {
 	}
 
 	@Test
+	void shallowCopyCopiesLinkAssociationAsIndependentInstance() {
+		ExtraLinkField original = new ExtraLinkField();
+		InventoryLink link = new InventoryLink();
+		link.setId(7L);
+		link.setTargetGlobalId("SA123v3");
+		link.setTargetPrefix(GlobalIdPrefix.SA);
+		link.setTargetDbId(123L);
+		link.setVersionPin(3L);
+		link.setTargetRevisionId(99L);
+		link.setRelationType("IsCalibratedBy");
+		original.setLink(link);
+
+		ExtraLinkField copy = original.shallowCopy();
+
+		assertNotNull(copy.getLink());
+		assertNotSame(original.getLink(), copy.getLink());
+		assertNull(copy.getLink().getId());
+		assertEquals("SA123v3", copy.getLink().getTargetGlobalId());
+		assertEquals(GlobalIdPrefix.SA, copy.getLink().getTargetPrefix());
+		assertEquals(123L, copy.getLink().getTargetDbId());
+		assertEquals(3L, copy.getLink().getVersionPin());
+		assertEquals(99L, copy.getLink().getTargetRevisionId());
+		assertEquals("IsCalibratedBy", copy.getLink().getRelationType());
+	}
+
+	@Test
+	void shallowCopyWithNullLinkProducesNullLink() {
+		ExtraLinkField original = new ExtraLinkField();
+		assertNull(original.shallowCopy().getLink());
+	}
+
+	@Test
 	void linkAssociationRoundTrips() {
 		ExtraLinkField field = new ExtraLinkField();
 		InventoryLink link = new InventoryLink();

--- a/src/test/java/com/researchspace/model/inventory/field/InventoryLinkFieldTest.java
+++ b/src/test/java/com/researchspace/model/inventory/field/InventoryLinkFieldTest.java
@@ -80,6 +80,22 @@ public class InventoryLinkFieldTest {
   }
 
   @Test
+  public void clearValueClearsLinkAssociation() {
+    InventoryLinkField field = new InventoryLinkField();
+    InventoryLink link = new InventoryLink();
+    link.setTargetGlobalId("SA10");
+    link.setRelationType("References");
+    field.setLink(link);
+
+    field.clearValue();
+
+    // the link field holds its value in the association, not the data column, so clearing the
+    // value must drop the link too (otherwise a template's link leaks into a newly added field)
+    assertNull(field.getLink());
+    assertNull(field.getData());
+  }
+
+  @Test
   public void shallowCopyLeavesLinkNullWhenSourceHasNoLink() {
     InventoryLinkField field = new InventoryLinkField();
     field.setName("Related items");

--- a/src/test/java/com/researchspace/model/inventory/field/InventoryLinkFieldTest.java
+++ b/src/test/java/com/researchspace/model/inventory/field/InventoryLinkFieldTest.java
@@ -1,0 +1,60 @@
+package com.researchspace.model.inventory.field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.field.FieldType;
+import org.junit.Test;
+
+public class InventoryLinkFieldTest {
+
+  @Test
+  public void fromFieldTypeStringCreatesLinkField() {
+    InventoryEntityField field = InventoryEntityField.fromFieldTypeString("link");
+    assertTrue(field instanceof InventoryLinkField);
+    assertEquals(FieldType.LINK, field.getType());
+  }
+
+  @Test
+  public void shallowCopyCopiesAllowedRelationTypesAndDeepCopiesLink() {
+    InventoryLinkField field = new InventoryLinkField();
+    field.setName("Related items");
+    field.setAllowedRelationTypes("References|IsDerivedFrom");
+    InventoryLink link = new InventoryLink();
+    link.setTargetGlobalId("SA10");
+    link.setTargetPrefix(GlobalIdPrefix.SA);
+    link.setTargetDbId(10L);
+    link.setRelationType("References");
+    link.setVersionPin(3L);
+    link.setTargetRevisionId(99L);
+    field.setLink(link);
+
+    InventoryLinkField copy = field.shallowCopy();
+
+    assertEquals("References|IsDerivedFrom", copy.getAllowedRelationTypes());
+    // deep copy: a new InventoryLink row, never the same instance
+    assertNotSame(link, copy.getLink());
+    assertNull(copy.getLink().getId());
+    assertEquals("SA10", copy.getLink().getTargetGlobalId());
+    assertEquals(GlobalIdPrefix.SA, copy.getLink().getTargetPrefix());
+    assertEquals(Long.valueOf(10), copy.getLink().getTargetDbId());
+    assertEquals("References", copy.getLink().getRelationType());
+    assertEquals(Long.valueOf(3), copy.getLink().getVersionPin());
+    assertEquals(Long.valueOf(99), copy.getLink().getTargetRevisionId());
+  }
+
+  @Test
+  public void shallowCopyLeavesLinkNullWhenSourceHasNoLink() {
+    InventoryLinkField field = new InventoryLinkField();
+    field.setName("Related items");
+    field.setAllowedRelationTypes("References");
+
+    InventoryLinkField copy = field.shallowCopy();
+
+    assertNull(copy.getLink());
+    assertEquals("References", copy.getAllowedRelationTypes());
+  }
+}

--- a/src/test/java/com/researchspace/model/inventory/field/InventoryLinkFieldTest.java
+++ b/src/test/java/com/researchspace/model/inventory/field/InventoryLinkFieldTest.java
@@ -1,6 +1,7 @@
 package com.researchspace.model.inventory.field;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -47,6 +48,35 @@ public class InventoryLinkFieldTest {
     assertEquals(Long.valueOf(99), copy.getLink().getTargetRevisionId());
     // deletion state must survive the clone (same path as InventoryLink.shallowCopy())
     assertTrue(copy.getLink().isDeleted());
+  }
+
+  @Test
+  public void mandatoryValidationRequiresNonBlankTargetGlobalIdAndRelationType() {
+    InventoryLinkField field = new InventoryLinkField();
+
+    // no link at all -> not valid
+    assertFalse(field.isValidValueForMandatoryField(null));
+
+    InventoryLink link = new InventoryLink();
+    field.setLink(link);
+
+    // link with neither target nor relation type -> not valid
+    assertFalse(field.isValidValueForMandatoryField(null));
+
+    // blank target (whitespace only) is not a real target -> not valid
+    link.setTargetGlobalId("   ");
+    link.setRelationType("References");
+    assertFalse(field.isValidValueForMandatoryField(null));
+
+    // target present but blank relation type -> not valid: relation_type is NOT NULL, so this
+    // would otherwise fail at flush with a low-level DB constraint violation
+    link.setTargetGlobalId("SA10");
+    link.setRelationType("");
+    assertFalse(field.isValidValueForMandatoryField(null));
+
+    // both present and non-blank -> valid
+    link.setRelationType("References");
+    assertTrue(field.isValidValueForMandatoryField(null));
   }
 
   @Test

--- a/src/test/java/com/researchspace/model/inventory/field/InventoryLinkFieldTest.java
+++ b/src/test/java/com/researchspace/model/inventory/field/InventoryLinkFieldTest.java
@@ -80,6 +80,28 @@ public class InventoryLinkFieldTest {
   }
 
   @Test
+  public void becomingMandatoryDuringTemplateUpdateDoesNotRejectAnEmptyLink() {
+    // A sample's link field synced to a template version that newly marks the link mandatory must
+    // not abort the "update samples to latest template version" run just because the link is still
+    // empty: a mandatory link is legitimately filled by a later, separate link update. (A
+    // data-column field in the same situation does still throw - see InventoryEntityFieldTest.)
+    InventoryLinkField templateField = new InventoryLinkField();
+    templateField.setName("related");
+    templateField.setMandatory(true);
+
+    InventoryLinkField field = new InventoryLinkField();
+    field.setName("related");
+    field.setTemplateField(templateField);
+
+    // the empty link is still reported "not yet valid" for an actual submission ...
+    assertFalse(field.isValidValueForMandatoryField(null));
+    // ... but syncing to the now-mandatory template definition must not throw
+    boolean updated = field.updateToLatestTemplateDefinition();
+    assertTrue(updated);
+    assertTrue(field.isMandatory());
+  }
+
+  @Test
   public void clearValueClearsLinkAssociation() {
     InventoryLinkField field = new InventoryLinkField();
     InventoryLink link = new InventoryLink();

--- a/src/test/java/com/researchspace/model/inventory/field/InventoryLinkFieldTest.java
+++ b/src/test/java/com/researchspace/model/inventory/field/InventoryLinkFieldTest.java
@@ -30,6 +30,7 @@ public class InventoryLinkFieldTest {
     link.setRelationType("References");
     link.setVersionPin(3L);
     link.setTargetRevisionId(99L);
+    link.setDeleted(true);
     field.setLink(link);
 
     InventoryLinkField copy = field.shallowCopy();
@@ -44,6 +45,8 @@ public class InventoryLinkFieldTest {
     assertEquals("References", copy.getLink().getRelationType());
     assertEquals(Long.valueOf(3), copy.getLink().getVersionPin());
     assertEquals(Long.valueOf(99), copy.getLink().getTargetRevisionId());
+    // deletion state must survive the clone (same path as InventoryLink.shallowCopy())
+    assertTrue(copy.getLink().isDeleted());
   }
 
   @Test

--- a/src/test/java/com/researchspace/model/inventory/field/InventoryLinkTest.java
+++ b/src/test/java/com/researchspace/model/inventory/field/InventoryLinkTest.java
@@ -3,6 +3,7 @@ package com.researchspace.model.inventory.field;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -39,6 +40,32 @@ class InventoryLinkTest {
 		InventoryLink link = new InventoryLink();
 		link.setTargetGlobalId("SA123");
 		assertNull(link.getVersionPin());
+	}
+
+	@Test
+	void shallowCopyCopiesPayloadButNotIdentityOrTimestamps() {
+		InventoryLink original = new InventoryLink();
+		original.setId(7L);
+		original.setTargetGlobalId("SA123v3");
+		original.setTargetPrefix(GlobalIdPrefix.SA);
+		original.setTargetDbId(123L);
+		original.setVersionPin(3L);
+		original.setTargetRevisionId(55L);
+		original.setRelationType("IsCalibratedBy");
+		original.prePersist();
+
+		InventoryLink copy = original.shallowCopy();
+
+		assertNotSame(original, copy);
+		assertNull(copy.getId());
+		assertNull(copy.getCreatedAt());
+		assertNull(copy.getModifiedAt());
+		assertEquals("SA123v3", copy.getTargetGlobalId());
+		assertEquals(GlobalIdPrefix.SA, copy.getTargetPrefix());
+		assertEquals(123L, copy.getTargetDbId());
+		assertEquals(3L, copy.getVersionPin());
+		assertEquals(55L, copy.getTargetRevisionId());
+		assertEquals("IsCalibratedBy", copy.getRelationType());
 	}
 
 	@Test

--- a/src/test/java/com/researchspace/model/inventory/field/InventoryLinkTest.java
+++ b/src/test/java/com/researchspace/model/inventory/field/InventoryLinkTest.java
@@ -69,6 +69,18 @@ class InventoryLinkTest {
 	}
 
 	@Test
+	void shallowCopyPreservesDeletedFlag() {
+		InventoryLink original = new InventoryLink();
+		original.setTargetGlobalId("SA123");
+		original.setTargetPrefix(GlobalIdPrefix.SA);
+		original.setTargetDbId(123L);
+		original.setRelationType("References");
+		original.setDeleted(true);
+
+		assertTrue(original.shallowCopy().isDeleted());
+	}
+
+	@Test
 	void prePersistSetsCreatedAtAndModifiedAt() {
 		InventoryLink link = new InventoryLink();
 		assertNull(link.getCreatedAt());

--- a/src/test/java/com/researchspace/model/inventory/field/InventoryLinkTest.java
+++ b/src/test/java/com/researchspace/model/inventory/field/InventoryLinkTest.java
@@ -1,0 +1,83 @@
+package com.researchspace.model.inventory.field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.Test;
+
+import com.researchspace.model.core.GlobalIdPrefix;
+
+class InventoryLinkTest {
+
+	@Test
+	void settersAndGettersRoundTrip() {
+		InventoryLink link = new InventoryLink();
+		link.setId(7L);
+		link.setTargetGlobalId("SA123v3");
+		link.setTargetPrefix(GlobalIdPrefix.SA);
+		link.setTargetDbId(123L);
+		link.setVersionPin(3L);
+		link.setRelationType("IsCalibratedBy");
+		link.setDeleted(true);
+
+		assertEquals(7L, link.getId());
+		assertEquals("SA123v3", link.getTargetGlobalId());
+		assertEquals(GlobalIdPrefix.SA, link.getTargetPrefix());
+		assertEquals(123L, link.getTargetDbId());
+		assertEquals(3L, link.getVersionPin());
+		assertEquals("IsCalibratedBy", link.getRelationType());
+		assertTrue(link.isDeleted());
+	}
+
+	@Test
+	void versionPinMayBeNullForLatest() {
+		InventoryLink link = new InventoryLink();
+		link.setTargetGlobalId("SA123");
+		assertNull(link.getVersionPin());
+	}
+
+	@Test
+	void prePersistSetsCreatedAtAndModifiedAt() {
+		InventoryLink link = new InventoryLink();
+		assertNull(link.getCreatedAt());
+		assertNull(link.getModifiedAt());
+
+		link.prePersist();
+
+		assertNotNull(link.getCreatedAt());
+		assertNotNull(link.getModifiedAt());
+		assertEquals(link.getCreatedAt(), link.getModifiedAt());
+	}
+
+	@Test
+	void prePersistPreservesExplicitlySetCreatedAt() {
+		InventoryLink link = new InventoryLink();
+		Date originalCreatedAt = new Date(1_700_000_000_000L);
+		link.setCreatedAt(originalCreatedAt);
+
+		link.prePersist();
+
+		assertEquals(originalCreatedAt, link.getCreatedAt());
+		assertNotNull(link.getModifiedAt());
+	}
+
+	@Test
+	void preUpdateAdvancesModifiedAtWithoutTouchingCreatedAt() throws InterruptedException {
+		InventoryLink link = new InventoryLink();
+		link.prePersist();
+		Date createdAt = link.getCreatedAt();
+		Date firstModifiedAt = link.getModifiedAt();
+
+		Thread.sleep(5);
+		link.preUpdate();
+
+		assertEquals(createdAt, link.getCreatedAt());
+		assertFalse(link.getModifiedAt().before(firstModifiedAt));
+	}
+
+}

--- a/src/test/java/com/researchspace/model/record/RecordFactoryTest.java
+++ b/src/test/java/com/researchspace/model/record/RecordFactoryTest.java
@@ -10,9 +10,12 @@ import com.researchspace.model.Group;
 import com.researchspace.model.Role;
 import com.researchspace.model.User;
 import com.researchspace.model.core.RecordType;
+import com.researchspace.model.field.FieldType;
 import com.researchspace.model.inventory.Instrument;
 import com.researchspace.model.inventory.InstrumentTemplate;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.field.ExtraField;
+import com.researchspace.model.inventory.field.ExtraLinkField;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,6 +34,13 @@ public class RecordFactoryTest {
 
 	@After
 	public void tearDown() throws Exception {
+	}
+
+	@Test
+	public void createExtraFieldLinkReturnsExtraLinkField() {
+		ExtraField field = factoryAPI.createExtraField(FieldType.LINK);
+		assertTrue(field instanceof ExtraLinkField);
+		assertEquals(FieldType.LINK, field.getType());
 	}
 
 	@Test


### PR DESCRIPTION
 ## Description ##

  Adds a new `LINK` inventory field type that lets inventory items reference other
  inventory items (RSDEV-1131). Pure model-layer change in `rspace-core-model`; the
  DB table and Liquibase migration live in the consuming `rspace-web` repo.

  New persistence model:
  - **`InventoryLink`** — `@Audited` entity for a typed, directional, optionally
    version-pinned link to another inventory item (`target_globalid` + `target_prefix`
    + `target_db_id`, `relation_type`, `version_pin`, `target_revision_id`, soft-delete
    `deleted`, `created_at`/`modified_at`).
  - **`ExtraLinkField`** — record-level `ExtraField` subclass (discriminator `link`)
    owning one `InventoryLink` via `@OneToOne(cascade = ALL, orphanRemoval = true)`.
  - **`InventoryLinkField`** — template-level field in the `InventoryEntityField`
    hierarchy (discriminator `link`); holds an optional `InventoryLink` plus a
    pipe-delimited `allowedRelationTypes` whitelist (empty = all relations allowed).
  - **`FieldType.LINK`** added (incl. `fromString` support) and wired into
    `RecordFactory.createExtraField(...)`.
  - **`InventoryEntityField.clearValue()`** hook so template-version updates reset
    association-backed fields correctly.

  Also: `pom.xml` version set to `2.26.0`; minor `.gitignore` tidy.

  ## Design decisions

  - **Denormalized target identity.** `targetGlobalId`, `targetPrefix` and `targetDbId`
    are stored together for query/display convenience rather than deriving the global id
    on read. Deliberate denormalization.
  - **Free-text `relationType`.** Stored as a plain column (DataCite-style relation
    names) rather than a closed enum, so callers aren't constrained to a fixed
    vocabulary; template fields may optionally restrict values via `allowedRelationTypes`.
  - **Version pinning.** `versionPin` is the user-facing version for display;
    `targetRevisionId` is the exact Envers audit-row (REV) the pin resolved to. A null
    pin means "latest" and resolves dynamically.
  - **Mapping on the getter, not the field.** The `@OneToOne`/`@JoinColumn` annotations
    sit on `getLink()` because the `ExtraField` / `InventoryEntityField` hierarchies use
    property access (`@Id` on `getId()`); field-level annotations would make Hibernate
    ignore `@JoinColumn` and fall back to the property name as the column.
  - **`@EqualsAndHashCode(of = {"id"})`** on `InventoryLink`, matching the existing
    entity convention in this module (`BasketItem`, `ExtraField`, etc.).
  - **Copy semantics.** `shallowCopy()` deep-copies the link into a fresh unsaved row
    (null id/timestamps) while preserving `deleted`, so copied samples/templates never
    share a managed link row. `ExtraLinkField` and `InventoryLinkField` both delegate to
    `InventoryLink.shallowCopy()` so the two clone paths can't diverge.
  - **`clearValue()` hook (not `instanceof`).** When a template-version update adds a new
    field to an existing sample it must start empty; the default clears the `data` column,
    and `InventoryLinkField` overrides it to also clear the `link` association.
  - **Mandatory validation matches the schema.** A mandatory link field requires a
    non-blank `targetGlobalId` and `relationType` (both `NOT NULL`), so an empty link
    fails validation cleanly instead of at flush time.

  ## Testing notes
  
  No prerequisites — all coverage is pure unit tests (no Spring context, no DB):

  ```bash
  mvn test -Dtest=InventoryLinkTest,InventoryLinkFieldTest,ExtraLinkFieldTest,RecordFactoryTest -Dfast=true

  Covers link payload/identity round-tripping, shallowCopy (deep copy, null id/timestamps,
  deleted preserved), mandatory-field validation (blank target/relation rejected),
  clearValue() clearing the link association, and RecordFactory returning an
  ExtraLinkField for FieldType.LINK. No UI changes (model library), so no screenshots.

 