### PR TITLE
RSDEV-1137: load Stoichiometry record/parentReaction via SELECT to stop molecule duplication

### DIFF
--- a/src/main/java/com/researchspace/model/stoichiometry/Stoichiometry.java
+++ b/src/main/java/com/researchspace/model/stoichiometry/Stoichiometry.java
@@ -59,7 +59,7 @@ public class Stoichiometry {
   // and produce a `molecules x folderMemberships` Cartesian product, so once the document is shared
   // (and therefore lives in more than one folder) every molecule row is returned duplicated. Loading
   // these to-one associations via a separate select keeps them out of the molecules join. The
-  // persisted rows are unaffected; this only governs how the eager graph is read back (RSDEV-1137).
+  // persisted rows are unaffected; this only governs how the eager graph is read back.
   @ManyToOne
   @Fetch(FetchMode.SELECT)
   @JoinColumn(name = "parent_reaction_id", nullable = true)

--- a/src/main/java/com/researchspace/model/stoichiometry/Stoichiometry.java
+++ b/src/main/java/com/researchspace/model/stoichiometry/Stoichiometry.java
@@ -27,6 +27,8 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 import org.hibernate.envers.Audited;
 
 @Entity
@@ -51,11 +53,20 @@ public class Stoichiometry {
   @Column(unique = true, nullable = false, length = 36)
   private String uuid = UUID.randomUUID().toString();
 
+  // SELECT, not the default JOIN: the eager `molecules` collection below is join-fetched, and the
+  // owning Record has its own eagerly-reachable folder-membership collection (RecordToFolder). If
+  // these to-one associations were join-fetched in the same query, that collection would join too
+  // and produce a `molecules x folderMemberships` Cartesian product, so once the document is shared
+  // (and therefore lives in more than one folder) every molecule row is returned duplicated. Loading
+  // these to-one associations via a separate select keeps them out of the molecules join. The
+  // persisted rows are unaffected; this only governs how the eager graph is read back (RSDEV-1137).
   @ManyToOne
+  @Fetch(FetchMode.SELECT)
   @JoinColumn(name = "parent_reaction_id", nullable = true)
   private RSChemElement parentReaction;
 
   @ManyToOne
+  @Fetch(FetchMode.SELECT)
   @JoinColumn(name = "record_id", nullable = false)
   private Record record;
 


### PR DESCRIPTION
## RSDEV-1137: Reaction table line items duplicate on save

### Root cause
Loading a `Stoichiometry` eagerly join-fetches its `molecules` collection and, by reaching the owning `Record`, that record's folder-membership collection (`RecordToFolder` / `parents`) in the same SQL query. Join-fetching two collections at once produces a Cartesian product (`molecules x folderMemberships`). When a document is shared into a lab group it belongs to 2 folders, so every molecule row is returned twice with identical primary keys.

The duplication is purely at read time: it shows up in the `GET` and in the update response the editor renders, but the persisted rows are never duplicated, which is why the saved / non-editable view is correct.

### Change
Annotate `Stoichiometry.record` and `Stoichiometry.parentReaction` with `@Fetch(FetchMode.SELECT)` so the owning `Record` (and its eager folder-membership collection) loads in a separate query rather than being join-fetched alongside the `molecules` bag. This breaks the Cartesian product while keeping `molecules` eagerly initialised, so there is no new lazy-loading exposure (an 11-line change to `Stoichiometry.java`).

Jira: https://researchspace.atlassian.net/browse/RSDEV-1137

rspace-web PR: https://github.com/rspace-os/rspace-web/pull/807

🤖 Generated with [Claude Code](https://claude.com/claude-code)
