### PR TITLE
RSDEV-1065: Refactoring to have `SampleTemplate` as a separate entity object

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,9 +2,12 @@
 
 Summary of important or breaking changes.
 
-## 2.28.0 2026-06-11
-- Amended the existing IdentifierType.DATACITE_IGSN to be IdentifierType.IGSN_DATACITE
-- Added new IdentifierType.PIDINST_DATACITE and IdentifierType.PIDINST_B2INST
+## 2.29.0 2026-06-24
+- New `SampleTemplate` entity to support sample templates in the inventory module
+
+## 2.28.0 2026-06-18
+- Amended the existing `IdentifierType.DATACITE_IGSN` to be `IdentifierType.IGSN_DATACITE`
+- Added new `IdentifierType.PIDINST_DATACITE` and `IdentifierType.PIDINST_B2INST`
 
 ## 2.27.0 2026-06-11
 - Restructuring core model to allow inventory linking

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rspace-core-model</artifactId>
-  <version>2.28.0</version>
+  <version>2.29.0</version>
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>

--- a/src/main/java/com/researchspace/model/inventory/InventoryRecord.java
+++ b/src/main/java/com/researchspace/model/inventory/InventoryRecord.java
@@ -73,7 +73,7 @@ public abstract class InventoryRecord {
 	private RecordSharingACL sharingACL;
 	
 	public enum InventoryRecordType {
-		SAMPLE, SUBSAMPLE, CONTAINER, INSTRUMENT, INSTRUMENT_TEMPLATE
+		SAMPLE, SAMPLE_TEMPLATE, SUBSAMPLE, CONTAINER, INSTRUMENT, INSTRUMENT_TEMPLATE
 	}
 
 	@Transient
@@ -248,14 +248,29 @@ public abstract class InventoryRecord {
 	@Transient
 	public abstract InventoryRecordType getType();
 
-	@Transient 
+	@Transient
 	public boolean isSample() {
 		return InventoryRecordType.SAMPLE.equals(getType());
 	}
 
-	@Transient 
+	@Transient
+	public boolean isSampleTemplate() {
+		return InventoryRecordType.SAMPLE_TEMPLATE.equals(getType());
+	}
+
+	@Transient
 	public boolean isSubSample() {
 		return InventoryRecordType.SUBSAMPLE.equals(getType());
+	}
+
+	/**
+	 * The {@link SampleTemplate} this record is based on, or {@code null} if none. Overridden
+	 * polymorphically (Sample returns its own template, SubSample delegates to its parent sample)
+	 * so callers need no unproxy/downcast when the record is a Hibernate proxy.
+	 */
+	@Transient
+	public SampleTemplate getLinkedSampleTemplate() {
+		return null;
 	}
 	
 	@Transient 
@@ -322,7 +337,14 @@ public abstract class InventoryRecord {
 
 	public void addAttachedFile(InventoryFile toAdd) {
 		assertCanStoreAttachments();
-		
+		doAddAttachedFile(toAdd);
+	}
+
+	/*
+	 * Skips assertCanStoreAttachments(), for use by the shallowCopyBasicFields() copy paths only:
+	 * a copy carries the origin's attachments even where direct attachment is rejected (e.g. SampleTemplate).
+	 */
+	private void doAddAttachedFile(InventoryFile toAdd) {
 		List<InventoryFile> files = getFiles();
 		if (!files.contains(toAdd)) {
 			toAdd.setInventoryRecord(this);
@@ -493,7 +515,7 @@ public abstract class InventoryRecord {
 			copy.addBarcode(barcode.shallowCopy());
 		}
 		for (InventoryFile invFile: getAttachedFiles()) {
-			copy.addAttachedFile(invFile.shallowCopy());
+			copy.doAddAttachedFile(invFile.shallowCopy());
 		}
 	}
 
@@ -514,7 +536,7 @@ public abstract class InventoryRecord {
 			destination.addBarcode(barcode.shallowCopy());
 		}
 		for (InventoryFile invFile: origin.getAttachedFiles()) {
-			destination.addAttachedFile(invFile.shallowCopy());
+			destination.doAddAttachedFile(invFile.shallowCopy());
 		}
 	}
 	

--- a/src/main/java/com/researchspace/model/inventory/InventoryRecordConnectedEntity.java
+++ b/src/main/java/com/researchspace/model/inventory/InventoryRecordConnectedEntity.java
@@ -28,7 +28,7 @@ public abstract class InventoryRecordConnectedEntity {
    * We want a foreign-key link to InventoryRecord, but as IR is abstract and not a db table
    * we need a field (column) for each concrete subclass i.e. Sample/SubSample/Container.
    */
-  private Sample sample;
+  private SampleEntity sample;
   private SubSample subSample;
   private Container container;
   private InstrumentEntity instrumentEntity;
@@ -57,8 +57,8 @@ public abstract class InventoryRecordConnectedEntity {
    * Sets parent
    */
   public void setInventoryRecord(InventoryRecord invRec) {
-    if (invRec instanceof Sample) {
-      sample = (Sample) invRec;
+    if (invRec instanceof SampleEntity) {
+      sample = (SampleEntity) invRec;
     } else if (invRec instanceof SubSample) {
       subSample = (SubSample) invRec;
     } else if (invRec instanceof Container) {
@@ -98,7 +98,7 @@ public abstract class InventoryRecordConnectedEntity {
   }
 
   @ManyToOne(cascade = CascadeType.MERGE)
-  public Sample getSample() {
+  public SampleEntity getSample() {
     return sample;
   }
 

--- a/src/main/java/com/researchspace/model/inventory/Sample.java
+++ b/src/main/java/com/researchspace/model/inventory/Sample.java
@@ -1,131 +1,53 @@
 package com.researchspace.model.inventory;
 
-import static com.researchspace.model.inventory.SampleSource.LAB_CREATED;
-
 import com.researchspace.model.User;
-import com.researchspace.model.audittrail.AuditDomain;
-import com.researchspace.model.audittrail.AuditTrailData;
 import com.researchspace.model.core.GlobalIdPrefix;
-import com.researchspace.model.core.UniquelyIdentifiable;
-import com.researchspace.model.inventory.field.ExtraField;
 import com.researchspace.model.inventory.field.InventoryEntityField;
-import com.researchspace.model.units.Quantifiable;
-import com.researchspace.model.units.QuantityInfo;
-import com.researchspace.model.units.QuantityUtils;
-import com.researchspace.model.units.RSUnitDef;
-import com.researchspace.model.units.ValidTemperature;
-import java.io.Serializable;
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.persistence.AttributeOverride;
-import javax.persistence.AttributeOverrides;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Embedded;
+import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.OrderBy;
 import javax.persistence.Transient;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang3.Validate;
 import org.hibernate.envers.Audited;
 import org.hibernate.envers.RelationTargetAuditMode;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
-import org.hibernate.search.annotations.IndexedEmbedded;
 
 /**
  * Represents RSpace Inventory Sample.
  */
 @Entity
+@DiscriminatorValue("Sample")
 @Audited
 @Getter
 @Setter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
-@AuditTrailData(auditDomain = AuditDomain.INV_SAMPLE)
 @Indexed
-public class Sample extends InventoryRecord implements Serializable, UniquelyIdentifiable,
-    Quantifiable {
+public class Sample extends SampleEntity {
 
-  private static final long serialVersionUID = 1867269597891360704L;
-
-  public static final int SUBSAMPLE_ALIAS_MAX_LENGTH = 30;
-
-  private User owner;
-
-  private QuantityInfo storageTempMin;
-  private QuantityInfo storageTempMax;
-
-  private List<SubSample> subSamples = new ArrayList<>();
-  private int activeSubSamplesCount;
-
-  @IndexedEmbedded
-  private List<InventoryEntityField> fields = new ArrayList<>();
-
-  @IndexedEmbedded(prefix = "fields.")
-  private List<ExtraField> extraFields = new ArrayList<>();
-
-  @IndexedEmbedded
-  private List<Barcode> barcodes = new ArrayList<>();
-
-  private List<DigitalObjectIdentifier> identifiers = new ArrayList<>();
-
-  @IndexedEmbedded(prefix = "fields.")
-  private List<InventoryFile> files = new ArrayList<>();
-
-  private SampleSource sampleSource = LAB_CREATED;
-
-  private LocalDate expiryDate;
-
-  @Setter(value = AccessLevel.PRIVATE)
-  private String subSampleName = SubSampleName.SUBSAMPLE.getDisplayName();
-  @Setter(value = AccessLevel.PRIVATE)
-  private String subSampleNamePlural = SubSampleName.SUBSAMPLE.getDisplayNamePlural();
-
-  /**
-   * 1st field has index = 1
-   */
-  private int currMaxColIndex = 0;
-
-  /**
-   * Boolean flag as to whether this sample is a template or not
-   */
-  private boolean isTemplate = false;
-
-  private Integer defaultUnitId;
+  private static final long serialVersionUID = 1L;
 
   /**
    * Template on which this sample is based on.
    */
-  private Sample sTemplate;
+  private SampleTemplate sTemplate;
 
   /**
    * Version of the template on which this sample is based on.
    */
-  @Setter(value = AccessLevel.PRIVATE)
+  @Setter(value = AccessLevel.PROTECTED)
   private Long sTemplateLinkedVersion;
-
-  private QuantityInfo quantityInfo;
 
   static final Set<String> RESERVED_FIELD_NAMES = Collections.unmodifiableSet(
       Stream.concat(
@@ -140,515 +62,74 @@ public class Sample extends InventoryRecord implements Serializable, UniquelyIde
           .collect(Collectors.toSet()));
 
   /**
-   * Reserved names for a Sample Template. Mirrors {@code TemplateModel.fieldNamesInUse} in the
-   * React UI: the template view is its own namespace and does NOT include the live-Sample labels
-   * (sample template / expiry date / etc.).
-   */
-  static final Set<String> SAMPLE_TEMPLATE_RESERVED_FIELD_NAMES = Collections.unmodifiableSet(
-      Stream.concat(
-              InventoryRecord.RESERVED_FIELD_NAMES.stream(),
-              Stream.of(
-                  "source",
-                  "expiry date",
-                  "subsample alias",
-                  "quantity units",
-                  "fields",
-                  "samples"))
-          .collect(Collectors.toSet()));
-
-  /**
    * for hibernate, record factory & pagination criteria
    */
   public Sample() {
+    super();
   }
 
-  @Enumerated(EnumType.STRING)
-  @Column(nullable = false)
-  @NotNull
-  public SampleSource getSampleSource() {
-    return sampleSource;
-  }
-
-  @ManyToOne
-  @JoinColumn(nullable = false)
-  @Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)
-  @IndexedEmbedded
-  public User getOwner() {
-    return owner;
-  }
-
-  @Embedded
-  @AttributeOverrides({
-      @AttributeOverride(name = "unitId", column = @Column(name = "storageTempMinUnitId")),
-      @AttributeOverride(name = "numericValue", column = @Column(name = "storageTempMinNumericValue", precision = 19, scale = 3))})
-  @ValidTemperature
-  public QuantityInfo getStorageTempMin() {
-    return storageTempMin;
-  }
-
-  @Embedded
-  @AttributeOverrides({
-      @AttributeOverride(name = "unitId", column = @Column(name = "storageTempMaxUnitId")),
-      @AttributeOverride(name = "numericValue", column = @Column(name = "storageTempMaxNumericValue", precision = 19, scale = 3))})
-  @ValidTemperature
-  public QuantityInfo getStorageTempMax() {
-    return storageTempMax;
-  }
-
-  /**
-   * @return the list of SubSample being part of this Sample
-   */
-  @OneToMany(mappedBy = "sample", cascade = CascadeType.ALL)
-  @Size(min = 1)
-  @OrderBy(value = "id")
-  public List<SubSample> getSubSamples() {
-    return subSamples;
-  }
-
-  public void setSubSamples(List<SubSample> subSamples) {
-    this.subSamples = subSamples;
-    refreshActiveSubSamples();
-  }
-
-  private List<SubSample> activeSubSamples;
-
-  @Transient
-  public List<SubSample> getActiveSubSamples() {
-    if (activeSubSamples == null) {
-      activeSubSamples = subSamples.stream()
-          .filter(ss -> !ss.isDeleted() || (isDeleted() && ss.isDeletedOnSampleDeletion()))
-          .collect(Collectors.toList());
-    }
-    return activeSubSamples;
-  }
-
-  public void refreshActiveSubSamples() {
-    activeSubSamples = null;
-    getActiveSubSamples();
-    activeSubSamplesCount = activeSubSamples.size();
+  protected Sample(SampleTemplate originTemplate, User currentUser) {
+    this();
+    shallowCopyBasicFields(originTemplate, this);
+    originTemplate.copyQuantityInfoTo(this);
+    copy(originTemplate, this, this::defaultNameCopy, currentUser);
+    setSampleTemplate(originTemplate);
+    setSTemplateLinkedVersion(originTemplate.getVersion());
   }
 
   @Transient
-  public List<SubSample> getDeletedSubSamples() {
-    return subSamples.stream().filter(ss -> ss.isDeleted())
-        .collect(Collectors.toList());
-  }
-
-  public boolean hasExactlyOneSubSample() {
-    return getActiveSubSamples().size() == 1;
-  }
-
-  /**
-   * If sample has just one subSample, retrieve it. Otherwise return empty optional.
-   */
-  @Transient
-  public Optional<SubSample> getOnlySubSample() {
-    return hasExactlyOneSubSample() ? Optional.of(getActiveSubSamples().get(0)) : Optional.empty();
-  }
-
-  /**
-   * @return the list of fields of this Sample
-   */
-  @OneToMany(mappedBy = "sample", cascade = CascadeType.ALL, orphanRemoval = true)
-  @OrderBy(value = "columnIndex")
-  protected List<InventoryEntityField> getFields() {
-    return fields;
-  }
-
-  protected void setFields(List<InventoryEntityField> fields) {
-    this.fields = fields;
-  }
-
-  private List<InventoryEntityField> activeFields;
-
-  /**
-   * @return list of non-deleted fields belonging to this Sample, sorted by columnIndex
-   */
-  @Transient
-  public List<InventoryEntityField> getActiveFields() {
-    if (activeFields == null) {
-      activeFields = getFields().stream().filter(sf -> !sf.isDeleted())
-          .sorted().collect(Collectors.toList());
-    }
-    return activeFields;
-  }
-
-  /**
-   * Appends a new InventoryEntityField to the list of this sample's fields, incrementing
-   * {@code currMaxColIndex} as a side-effect.
-   *
-   * @param toAdd
-   */
-  public void addSampleField(InventoryEntityField toAdd) {
-    verifyFieldNameAllowed(toAdd.getName());
-    currMaxColIndex++;
-    if (toAdd.getColumnIndex() == null) {
-      toAdd.setColumnIndex(currMaxColIndex);
-    }
-    toAdd.setInventoryRecord(this);
-    fields.add(toAdd);
-    refreshActiveFields();
-  }
-
-  /**
-   * Resets column index property for active fields, so they start from 1 and end with
-   * currMaxColIndex.
-   */
-  public void refreshActiveFieldsAndColumnIndex() {
-    currMaxColIndex = 0;
-    activeFields = null;
-    for (InventoryEntityField sf : getActiveFields()) {
-      sf.setColumnIndex(++currMaxColIndex);
-    }
-  }
-
-  public void deleteSampleField(InventoryEntityField toDelete, boolean deleteOnSampleUpdate) {
-    if (!isTemplate()) {
-      throw new IllegalArgumentException(
-          "Cannot directly delete field from sample, only from template");
-    }
-    Optional<InventoryEntityField> fieldToDeleteOpt = getFieldById(toDelete.getId());
-    if (!fieldToDeleteOpt.isPresent()) {
-      throw new IllegalArgumentException(
-          "Trying to delete a field not belonging to current sample");
-    }
-    InventoryEntityField fieldToDelete = fieldToDeleteOpt.get();
-    fieldToDelete.setDeleted(true);
-    fieldToDelete.setDeleteOnSampleUpdate(deleteOnSampleUpdate);
-    refreshActiveFields();
-  }
-
-  public Optional<InventoryEntityField> getFieldById(Long id) {
-    return getFields().stream().filter(sf -> id != null && id.equals(sf.getId())).findFirst();
-  }
-
-  private Optional<InventoryEntityField> getFieldByTemplateFieldId(Long id) {
-    return getFields().stream()
-        .filter(sf -> id != null && sf.getTemplateField() != null && id.equals(
-            sf.getTemplateField().getId()))
-        .findFirst();
-  }
-
-  public List<InventoryEntityField> refreshActiveFields() {
-    activeFields = null;
-    return getActiveFields();
-  }
-
-  @NotNull
-  @Column(length = SUBSAMPLE_ALIAS_MAX_LENGTH)
-  private String getSubSampleName() {
-    return subSampleName;
-  }
-
-  @NotNull
-  @Column(length = SUBSAMPLE_ALIAS_MAX_LENGTH)
-  private String getSubSampleNamePlural() {
-    return subSampleNamePlural;
-  }
-
-  @Transient
-  public String getSubSampleAlias() {
-    return getSubSampleName();
-  }
-
-  @Transient
-  public String getSubSampleAliasPlural() {
-    return getSubSampleNamePlural();
-  }
-
-  @Transient
-  public void setSubSampleAliases(String alias, String aliasPlural) {
-    Validate.notBlank(alias, "SubSample alias cannot be blank");
-    Validate.notBlank(aliasPlural, "SubSample alias (plural) cannot be blank");
-    setSubSampleName(StringUtils.trim(alias));
-    setSubSampleNamePlural(StringUtils.trim(aliasPlural));
-  }
-
-  @Transient
-  public void setSubSampleAliases(SubSampleName name) {
-    setSubSampleName(name.getDisplayName());
-    setSubSampleNamePlural(name.getDisplayNamePlural());
-  }
-
-  @Embedded
-  @AttributeOverrides({
-      @AttributeOverride(name = "unitId", column = @Column(name = "quantityUnitId")),
-      @AttributeOverride(name = "numericValue", column = @Column(name = "quantityNumericValue", precision = 19, scale = 3))
-  })
-  public QuantityInfo getQuantityInfo() {
-    return quantityInfo;
-  }
-
-  /* marked 'protected' so concrete subclass methods are used by the code outside */
-  protected void setQuantityInfo(QuantityInfo quantityInfo) {
-    if (quantityInfo != null && quantityInfo.getUnitId() != null) {
-      if (BigDecimal.ZERO.compareTo(quantityInfo.getNumericValue()) > 0) {
-        throw new IllegalArgumentException(
-            "Trying to set negative record quantity: " + quantityInfo.getNumericValuePlainString());
-      }
-    }
-    this.quantityInfo = quantityInfo;
-  }
-
   @Override
+  public boolean isTemplate() {
+    return false;
+  }
+
   @Transient
-  public Integer getUnitId() {
-    return getQuantityInfo().getUnitId();
-  }
-
   @Override
-  @Transient
-  public BigDecimal getNumericValue() {
-    return getQuantityInfo().getNumericValue();
-  }
-
-  /**
-   * Retrieve total quantity of the Sample. The total value is a sum of all subsample quantities,
-   * rounded to 3 fraction digits.
-   */
-  @Transient
-  public QuantityInfo getTotalQuantity() {
-    return this.getQuantityInfo();
-  }
-
-  /**
-   * Set total quantity of the Sample. Can be called only if sample has a single subsample, throws
-   * exception otherwise.
-   */
-  public void setTotalQuantity(QuantityInfo quantityInfo) {
-    if (hasExactlyOneSubSample()) {
-      this.setQuantityInfo(quantityInfo);
-      getActiveSubSamples().get(0).setQuantityInfo(quantityInfo);
-    } else {
-      throw new IllegalStateException(
-          "Can't save total quantity directly in Sample having multiple SubSamples");
-    }
-  }
-
-  public void recalculateTotalQuantity() {
-    QuantityUtils quantityUtils = new QuantityUtils();
-    List<QuantityInfo> subSampleQuantities = getActiveSubSamples().stream()
-        .filter(ss -> ss.getQuantity() != null)
-        .map(ss -> ss.getQuantity()).collect(Collectors.toList());
-
-    if (subSampleQuantities.isEmpty()) {
-      setQuantityInfo(null);
-      return;
-    }
-    if (subSampleQuantities.size() == 1) {
-      setQuantityInfo(subSampleQuantities.get(0));
-      return;
-    }
-
-    QuantityInfo totalQuantity = quantityUtils.sum(subSampleQuantities);
-    setQuantityInfo(totalQuantity);
-  }
-
-  /**
-   * @return the list of extra fields of this Sample, including deleted fields.
-   */
-  @OneToMany(mappedBy = "sample", cascade = CascadeType.ALL, orphanRemoval = true)
-  @OrderBy(value = "id")
-  @Override
-  protected List<ExtraField> getExtraFields() {
-    return extraFields;
-  }
-
-  protected void setExtraFields(List<ExtraField> extraFields) {
-    this.extraFields = extraFields;
-    refreshActiveExtraFields();
-  }
-
-  /**
-   * @return the list of barcodes of this SubSample, including deleted fields.
-   */
-  @OneToMany(mappedBy = "sample", cascade = CascadeType.ALL, orphanRemoval = true)
-  @OrderBy(value = "id")
-  @Override
-  protected List<Barcode> getBarcodes() {
-    return barcodes;
-  }
-
-  protected void setBarcodes(List<Barcode> barcodes) {
-    this.barcodes = barcodes;
-    refreshActiveBarcodes();
-  }
-
-  @OneToMany(mappedBy = "sample", cascade = CascadeType.ALL, orphanRemoval = true)
-  @OrderBy(value = "id")
-  @Override
-  protected List<DigitalObjectIdentifier> getIdentifiers() {
-    return identifiers;
-  }
-
-  protected void setIdentifiers(List<DigitalObjectIdentifier> identifiers) {
-    this.identifiers = identifiers;
-    refreshActiveIdentifiers();
-  }
-
-  /**
-   * @return the list of files attached to this Sample
-   */
-  @OneToMany(mappedBy = "sample", cascade = CascadeType.ALL, orphanRemoval = true)
-  @OrderBy(value = "id")
-  protected List<InventoryFile> getFiles() {
-    return files;
-  }
-
-  protected void setFiles(List<InventoryFile> files) {
-    this.files = files;
-    refreshActiveAttachedFiles();
+  public InventoryRecordType getType() {
+    return InventoryRecordType.SAMPLE;
   }
 
   @Transient
   @Override
   public GlobalIdPrefix getGlobalIdPrefix() {
-    return isTemplate ? GlobalIdPrefix.IT : GlobalIdPrefix.SA;
+    return GlobalIdPrefix.SA;
   }
 
-  @Transient
   @Override
-  public InventoryRecord.InventoryRecordType getType() {
-    return InventoryRecordType.SAMPLE;
+  public SampleTemplate copyToTemplate(User currentUser) {
+    return new SampleTemplate(this, currentUser);
   }
 
-  /**
-   * Adds subsample setting both sides of the relationship and refreshing active subsamples.
-   *
-   * @param subSampleToAdd
-   */
-  public void addSubSample(SubSample subSampleToAdd) {
-    this.subSamples.add(subSampleToAdd);
-    subSampleToAdd.setSample(this);
-    refreshActiveSubSamples();
-  }
-
-  Sample shallowCopy() {
-    Sample copy = new Sample();
-    shallowCopyBasicFields(copy);
-    if (getQuantityInfo() != null) {
-      copy.setQuantityInfo(getQuantityInfo().copy());
-    }
-    return copy;
-  }
-
-  /**
-   * Convenience copy method to make a normal sample from a template. Validates that this object
-   * <em>is</em> a template, also sets the template and its version into copied sample.
-   *
-   * @return a copy of a template, a regular sample.
-   * @throws IllegalArgumentException if this Sample is not a template
-   */
-  public Sample copyFromTemplate(User currentUser) {
-    Validate.isTrue(isTemplate(), templateErrMsg(this, true));
-    Sample copy = this.copy(false, currentUser);
-    copy.setSTemplate(this);
-    copy.setSTemplateLinkedVersion(getVersion());
-    return copy;
-  }
-
-  /**
-   * Convenience copy method to make a template from a sample, or template. This is the inverse
-   * operation to {@code copyFromTemplate}
-   *
-   * @return a copy of the sample, as a Template.
-   * @throws IllegalArgumentException if this Sample <em>is</em> a template
-   */
-  public Sample copyToTemplate(User currentUser) {
-    return this.copy(true, currentUser);
-  }
-
-  private String templateErrMsg(Sample template, boolean shouldBeTemplate) {
-    return String.format("the sample argument (id=%d) is ", template.getId()) + (shouldBeTemplate
-        ? "not" : "") + " a template";
-  }
-
-  /**
-   * Duplicates this sample (or template), including fields, core properties, icons and images. Does
-   * not copy subsamples, but creates a single sample with same quantity as original.
-   *
-   * @param currentUser user to set as a creator and owner of the copy
-   * @return the newly duplicated sample.
-   */
   @Override
-  public Sample copy(User currentUser) {
-    return this.copy(isTemplate(), currentUser);
-  }
-
-  private Sample copy(boolean toTemplate, User currentUser) {
-    return copy(this::defaultNameCopy, toTemplate, currentUser);
-  }
-
-  /**
-   * @param nameMapper A custom name-mapper to generate name for the new copy.
-   * @return
-   * @see Sample#copy(User)
-   */
-  private Sample copy(Function<Sample, String> nameMapper, boolean toTemplate, User currentUser) {
-    QuantityInfo toCopyTotal = this.getTotalQuantity();
-    Sample sampleCopy = shallowCopy();
-    sampleCopy.setExpiryDate(getExpiryDate());
-    sampleCopy.setName(nameMapper.apply(this));
-    sampleCopy.setImageFileProperty(getImageFileProperty());
-    sampleCopy.setThumbnailFileProperty(getThumbnailFileProperty());
-    sampleCopy.setCreatedBy(currentUser.getUsername());
-    sampleCopy.setModifiedBy(currentUser.getUsername());
-    sampleCopy.setOwner(currentUser);
-    sampleCopy.setStorageTempMax(getStorageTempMax());
-    sampleCopy.setStorageTempMin(getStorageTempMin());
-    sampleCopy.setSubSampleName(getSubSampleName());
-    sampleCopy.setSubSampleNamePlural(getSubSampleNamePlural());
-    sampleCopy.setDefaultUnitId(getDefaultUnitId());
-    sampleCopy.setSampleSource(getSampleSource());
-    // don't need to set currMaxColIndexIndex as is set by adding fields
-
-    sampleCopy.setTemplate(toTemplate);
-    if (!toTemplate) {
-      sampleCopy.setSampleTemplate(getSTemplate());
-      sampleCopy.setSTemplateLinkedVersion(getSTemplateLinkedVersion());
-    }
-
-    for (InventoryEntityField field : getFields()) {
-      sampleCopy.copyAndAddSampleField(field);
-    }
-    createSubSample(nameMapper, toCopyTotal, sampleCopy);
-    return sampleCopy;
-  }
-
-  private InventoryEntityField copyAndAddSampleField(InventoryEntityField field) {
-    InventoryEntityField copiedField = field.shallowCopy();
-    /* if copying into a sample set connection to original template field */
-    if (!isTemplate()) {
-      /* if copying a field belonging to a template, set that field as a template field,
-       * but if copying a field belonging to a non-template (i.e. sample), set
-       * the original template field as a template field */
-      copiedField.setTemplateField(
-          field.getSample().isTemplate() ? field : field.getTemplateField());
-    }
-    addSampleField(copiedField);
-    return copiedField;
+  public SampleEntity copyFromTemplate(User currentUser) {
+    throw new IllegalStateException("Only a SampleTemplate can be used to copy from a template");
   }
 
   /**
    * If this sample was created from a template, returns the template, else {@code null}.
    * <p>
-   * This will be {@code null} if any of the following are true:
-   * <ul>
-   * <li> This Sample <em>is</em> a template
-   * <li> This Sample is a free-form sample created from scratch, not using a template.
-   * </ul>
+   * This will be {@code null} if this Sample is a free-form sample created from scratch, not
+   * using a template.
+   * <p>
    * This association is lazy-loaded.
    *
    * @return
    */
   @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "STemplate_id")
   @Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)
-  public Sample getSTemplate() {
+  public SampleTemplate getSTemplate() {
     return sTemplate;
   }
 
+  @Override
+  @Transient
+  public SampleTemplate getLinkedSampleTemplate() {
+    return getSTemplate();
+  }
+
   // for hibernate, does not perform validation so as to support setting lazy proxies with null values.
-  void setSTemplate(Sample template) {
+  void setSTemplate(SampleTemplate template) {
     this.sTemplate = template;
   }
 
@@ -656,13 +137,8 @@ public class Sample extends InventoryRecord implements Serializable, UniquelyIde
    * Public setter for the  template used to create this sample
    *
    * @param template
-   * @throws IllegalArgumentException if {@code template} is not a template (i.e
-   *                                  {@code isTemplate()==false} ).
    */
-  public void setSampleTemplate(Sample template) {
-    if (template != null) {
-      Validate.isTrue(template.isTemplate(), templateErrMsg(template, true));
-    }
+  public void setSampleTemplate(SampleTemplate template) {
     this.sTemplate = template;
   }
 
@@ -675,45 +151,13 @@ public class Sample extends InventoryRecord implements Serializable, UniquelyIde
     return null;
   }
 
-  @NotNull
-  @Column(nullable = false)
-  public Integer getDefaultUnitId() {
-    return defaultUnitId;
-  }
-
-  private void createSubSample(Function<Sample, String> nameMapper, QuantityInfo toCopyTotal,
-      Sample sample) {
-    SubSample singleSS = new SubSample(sample);
-    sample.addSubSample(singleSS);
-    String ssName = InventorySeriesNamingHelper.getSerialNameForSubSample(nameMapper.apply(this), 1,
-        1);
-    singleSS.setName(ssName);
-
-    QuantityInfo newQuantity = toCopyTotal != null ? toCopyTotal.copy()
-        : QuantityInfo.zero(RSUnitDef.getUnitById(getDefaultUnitId()));
-    singleSS.setQuantity(newQuantity);
-    singleSS.setCreatedBy(sample.getCreatedBy());
-    singleSS.setModifiedBy(sample.getModifiedBy());
-  }
-
   @Override
   @Transient
   public Set<String> getReservedFieldNames() {
-    return isTemplate() ? SAMPLE_TEMPLATE_RESERVED_FIELD_NAMES : RESERVED_FIELD_NAMES;
-  }
-
-  @Override
-  protected void assertCanStoreAttachments() {
-    if (isTemplate()) {
-      throw new IllegalArgumentException("Sample Templates don't support file attachments yet");
-    }
+    return RESERVED_FIELD_NAMES;
   }
 
   public boolean updateToLatestTemplateVersion() {
-    if (isTemplate()) {
-      throw new IllegalStateException(
-          "Update to latest template version is only supported for samples, not templates");
-    }
     if (getSTemplate() == null) {
       throw new IllegalStateException("The sample is not based on any template");
     }
@@ -767,13 +211,34 @@ public class Sample extends InventoryRecord implements Serializable, UniquelyIde
     return sampleUpdated;
   }
 
+  private Optional<InventoryEntityField> getFieldByTemplateFieldId(Long id) {
+    return getFields().stream()
+        .filter(sf -> id != null && sf.getTemplateField() != null && id.equals(
+            sf.getTemplateField().getId()))
+        .findFirst();
+  }
+
+  @Override
+  protected SampleEntity shallowCopy() {
+    Sample copy = new Sample();
+    shallowCopyBasicFields(copy);
+    copyQuantityInfoTo(copy);
+    return copy;
+  }
+
   /**
-   * Checks if provided alias singular and plural are equal to ones set in this Sample.
+   * Duplicates this sample, including fields, core properties, icons and images. Does
+   * not copy subsamples, but creates a single sample with same quantity as original.
+   *
+   * @param currentUser user to set as a creator and owner of the copy
+   * @return the newly duplicated sample.
    */
-  public boolean isSubSampleAliasEqualTo(String subSampleAlias, String subSampleAliasPlural) {
-    return getSubSampleAlias().equals(subSampleAlias) && getSubSampleAliasPlural().equals(
-        subSampleAliasPlural);
+  @Override
+  public Sample copy(User currentUser) {
+    Sample copiedSample = super.copy(this::defaultNameCopy, currentUser);
+    copiedSample.setSampleTemplate(getSTemplate());
+    copiedSample.setSTemplateLinkedVersion(getSTemplateLinkedVersion());
+    return copiedSample;
   }
 
 }
-

--- a/src/main/java/com/researchspace/model/inventory/SampleEntity.java
+++ b/src/main/java/com/researchspace/model/inventory/SampleEntity.java
@@ -1,0 +1,576 @@
+package com.researchspace.model.inventory;
+
+import static com.researchspace.model.inventory.SampleSource.LAB_CREATED;
+
+import com.researchspace.model.User;
+import com.researchspace.model.audittrail.AuditDomain;
+import com.researchspace.model.audittrail.AuditTrailData;
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.core.UniquelyIdentifiable;
+import com.researchspace.model.inventory.field.ExtraField;
+import com.researchspace.model.inventory.field.InventoryEntityField;
+import com.researchspace.model.units.Quantifiable;
+import com.researchspace.model.units.QuantityInfo;
+import com.researchspace.model.units.QuantityUtils;
+import com.researchspace.model.units.RSUnitDef;
+import com.researchspace.model.units.ValidTemperature;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.persistence.AttributeOverride;
+import javax.persistence.AttributeOverrides;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.Validate;
+import org.hibernate.envers.Audited;
+import org.hibernate.envers.RelationTargetAuditMode;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.IndexedEmbedded;
+
+/**
+ * Represents RSpace Inventory SampleEntity (that is Sample or SampleTemplate)
+ */
+@Entity(name = "SampleEntity")
+@Table(name = "Sample")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+/*
+ * Single-table inheritance over the legacy "Sample" table, mirroring InstrumentEntity. The
+ * discriminator is Hibernate's default DTYPE column (varchar, values "Sample"/"SampleTemplate"),
+ * added to Sample and Sample_AUD by changeLog-rsdev-1065.xml and backfilled from the legacy
+ * "template" flag. The legacy "template" column is kept but no longer mapped, so HQL must query
+ * Sample/SampleTemplate (or use TYPE()), not a "template" property.
+ */
+@Audited
+@Getter
+@Setter
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
+@AuditTrailData(auditDomain = AuditDomain.INV_SAMPLE)
+@Indexed
+public abstract class SampleEntity extends InventoryRecord implements Serializable,
+    UniquelyIdentifiable, Quantifiable {
+
+  private static final long serialVersionUID = 1867269597891360704L;
+
+  public static final int SUBSAMPLE_ALIAS_MAX_LENGTH = 30;
+
+  private User owner;
+
+  private QuantityInfo storageTempMin;
+  private QuantityInfo storageTempMax;
+
+  private List<SubSample> subSamples = new ArrayList<>();
+  private int activeSubSamplesCount;
+
+  @IndexedEmbedded
+  private List<InventoryEntityField> fields = new ArrayList<>();
+
+  @IndexedEmbedded(prefix = "fields.")
+  private List<ExtraField> extraFields = new ArrayList<>();
+
+  @IndexedEmbedded
+  private List<Barcode> barcodes = new ArrayList<>();
+
+  private List<DigitalObjectIdentifier> identifiers = new ArrayList<>();
+
+  @IndexedEmbedded(prefix = "fields.")
+  private List<InventoryFile> files = new ArrayList<>();
+
+  private SampleSource sampleSource = LAB_CREATED;
+
+  private LocalDate expiryDate;
+
+  @Setter(value = AccessLevel.PRIVATE)
+  private String subSampleName = SubSampleName.SUBSAMPLE.getDisplayName();
+  @Setter(value = AccessLevel.PRIVATE)
+  private String subSampleNamePlural = SubSampleName.SUBSAMPLE.getDisplayNamePlural();
+
+  /**
+   * 1st field has index = 1
+   */
+  private int currMaxColIndex = 0;
+
+  private Integer defaultUnitId;
+
+  private QuantityInfo quantityInfo;
+
+  public SampleEntity() {
+  }
+
+  @Transient
+  public abstract boolean isTemplate();
+
+  @Transient
+  public abstract GlobalIdPrefix getGlobalIdPrefix();
+
+  /**
+   * Convenience copy method to make a template from a sample. This is the inverse operation to
+   * {@code copyFromTemplate}
+   *
+   * @return a copy of the sample, as a Template.
+   * @throws IllegalArgumentException if this SampleEntity <em>is</em> a template
+   */
+  public abstract SampleEntity copyToTemplate(User currentUser);
+
+  /**
+   * Convenience copy method to make a normal sample from a template. Validates that this object
+   * <em>is</em> a template, also sets the template and its version into copied sample.
+   *
+   * @return a copy of a template, a regular sample.
+   * @throws IllegalStateException if this SampleEntity is not a template
+   */
+  public abstract SampleEntity copyFromTemplate(User currentUser);
+
+  /**
+   * @param nameMapper A custom name-mapper to generate name for the new copy.
+   * @return
+   * @see SampleEntity#copy(User)
+   */
+  protected <T extends SampleEntity> T copy(Function<SampleEntity, String> nameMapper,
+      User currentUser) {
+    T sampleCopy = this.shallowCopy();
+    copy(this, sampleCopy, nameMapper, currentUser);
+    return sampleCopy;
+  }
+
+  static void copy(SampleEntity origin, SampleEntity destination,
+      Function<SampleEntity, String> nameMapper, User currentUser) {
+    QuantityInfo toCopyTotal = origin.getTotalQuantity();
+    destination.setExpiryDate(origin.getExpiryDate());
+    destination.setName(nameMapper.apply(origin));
+    destination.setImageFileProperty(origin.getImageFileProperty());
+    destination.setThumbnailFileProperty(origin.getThumbnailFileProperty());
+    destination.setCreatedBy(currentUser.getUsername());
+    destination.setModifiedBy(currentUser.getUsername());
+    destination.setOwner(currentUser);
+    destination.setStorageTempMax(origin.getStorageTempMax());
+    destination.setStorageTempMin(origin.getStorageTempMin());
+    destination.setSubSampleName(origin.getSubSampleName());
+    destination.setSubSampleNamePlural(origin.getSubSampleNamePlural());
+    destination.setDefaultUnitId(origin.getDefaultUnitId());
+    destination.setSampleSource(origin.getSampleSource());
+    // don't need to set currMaxColIndex as is set by adding fields
+
+    for (InventoryEntityField field : origin.getFields()) {
+      destination.copyAndAddSampleField(field);
+    }
+    origin.createSubSample(nameMapper, toCopyTotal, destination);
+  }
+
+  protected void copyQuantityInfoTo(SampleEntity copy) {
+    if (getQuantityInfo() != null) {
+      copy.setQuantityInfo(getQuantityInfo().copy());
+    }
+  }
+
+  protected InventoryEntityField copyAndAddSampleField(InventoryEntityField field) {
+    InventoryEntityField copiedField = field.shallowCopy();
+    /* if copying into a sample set connection to original template field */
+    if (!isTemplate()) {
+      /* if copying a field belonging to a template, set that field as a template field,
+       * but if copying a field belonging to a non-template (i.e. sample), set
+       * the original template field as a template field */
+      copiedField.setTemplateField(
+          field.getSample().isTemplate() ? field : field.getTemplateField());
+    }
+    addSampleField(copiedField);
+    return copiedField;
+  }
+
+  private void createSubSample(Function<SampleEntity, String> nameMapper, QuantityInfo toCopyTotal,
+      SampleEntity sample) {
+    SubSample singleSS = new SubSample(sample);
+    sample.addSubSample(singleSS);
+    String ssName = InventorySeriesNamingHelper.getSerialNameForSubSample(nameMapper.apply(this), 1,
+        1);
+    singleSS.setName(ssName);
+
+    QuantityInfo newQuantity = toCopyTotal != null ? toCopyTotal.copy()
+        : QuantityInfo.zero(RSUnitDef.getUnitById(getDefaultUnitId()));
+    singleSS.setQuantity(newQuantity);
+    singleSS.setCreatedBy(sample.getCreatedBy());
+    singleSS.setModifiedBy(sample.getModifiedBy());
+  }
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  @NotNull
+  public SampleSource getSampleSource() {
+    return sampleSource;
+  }
+
+  @NotNull
+  @Column(nullable = false)
+  public Integer getDefaultUnitId() {
+    return defaultUnitId;
+  }
+
+  @ManyToOne
+  @JoinColumn(nullable = false)
+  @Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)
+  @IndexedEmbedded
+  public User getOwner() {
+    return owner;
+  }
+
+  @Embedded
+  @AttributeOverrides({
+      @AttributeOverride(name = "unitId", column = @Column(name = "storageTempMinUnitId")),
+      @AttributeOverride(name = "numericValue", column = @Column(name = "storageTempMinNumericValue", precision = 19, scale = 3))})
+  @ValidTemperature
+  public QuantityInfo getStorageTempMin() {
+    return storageTempMin;
+  }
+
+  @Embedded
+  @AttributeOverrides({
+      @AttributeOverride(name = "unitId", column = @Column(name = "storageTempMaxUnitId")),
+      @AttributeOverride(name = "numericValue", column = @Column(name = "storageTempMaxNumericValue", precision = 19, scale = 3))})
+  @ValidTemperature
+  public QuantityInfo getStorageTempMax() {
+    return storageTempMax;
+  }
+
+  /**
+   * @return the list of SubSample being part of this Sample
+   */
+  @OneToMany(mappedBy = "sample", cascade = CascadeType.ALL)
+  @Size(min = 1)
+  @OrderBy(value = "id")
+  public List<SubSample> getSubSamples() {
+    return subSamples;
+  }
+
+  public void setSubSamples(List<SubSample> subSamples) {
+    this.subSamples = subSamples;
+    refreshActiveSubSamples();
+  }
+
+  private List<SubSample> activeSubSamples;
+
+  @Transient
+  public List<SubSample> getActiveSubSamples() {
+    if (activeSubSamples == null) {
+      activeSubSamples = subSamples.stream()
+          .filter(ss -> !ss.isDeleted() || (isDeleted() && ss.isDeletedOnSampleDeletion()))
+          .collect(Collectors.toList());
+    }
+    return activeSubSamples;
+  }
+
+  public void refreshActiveSubSamples() {
+    activeSubSamples = null;
+    getActiveSubSamples();
+    activeSubSamplesCount = activeSubSamples.size();
+  }
+
+  @Transient
+  public List<SubSample> getDeletedSubSamples() {
+    return subSamples.stream().filter(ss -> ss.isDeleted())
+        .collect(Collectors.toList());
+  }
+
+  public boolean hasExactlyOneSubSample() {
+    return getActiveSubSamples().size() == 1;
+  }
+
+  /**
+   * If sample has just one subSample, retrieve it. Otherwise return empty optional.
+   */
+  @Transient
+  public Optional<SubSample> getOnlySubSample() {
+    return hasExactlyOneSubSample() ? Optional.of(getActiveSubSamples().get(0)) : Optional.empty();
+  }
+
+  /**
+   * @return the list of fields of this Sample
+   */
+  @OneToMany(mappedBy = "sample", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OrderBy(value = "columnIndex")
+  protected List<InventoryEntityField> getFields() {
+    return fields;
+  }
+
+  protected void setFields(List<InventoryEntityField> fields) {
+    this.fields = fields;
+  }
+
+  private List<InventoryEntityField> activeFields;
+
+  /**
+   * @return list of non-deleted fields belonging to this Sample, sorted by columnIndex
+   */
+  @Transient
+  public List<InventoryEntityField> getActiveFields() {
+    if (activeFields == null) {
+      activeFields = getFields().stream().filter(sf -> !sf.isDeleted())
+          .sorted().collect(Collectors.toList());
+    }
+    return activeFields;
+  }
+
+  /**
+   * Appends a new InventoryEntityField to the list of this sample's fields, incrementing
+   * {@code currMaxColIndex} as a side-effect.
+   *
+   * @param toAdd
+   */
+  public void addSampleField(InventoryEntityField toAdd) {
+    verifyFieldNameAllowed(toAdd.getName());
+    currMaxColIndex++;
+    if (toAdd.getColumnIndex() == null) {
+      toAdd.setColumnIndex(currMaxColIndex);
+    }
+    toAdd.setInventoryRecord(this);
+    fields.add(toAdd);
+    refreshActiveFields();
+  }
+
+  /**
+   * Resets column index property for active fields, so they start from 1 and end with
+   * currMaxColIndex.
+   */
+  public void refreshActiveFieldsAndColumnIndex() {
+    currMaxColIndex = 0;
+    activeFields = null;
+    for (InventoryEntityField sf : getActiveFields()) {
+      sf.setColumnIndex(++currMaxColIndex);
+    }
+  }
+
+  public void deleteSampleField(InventoryEntityField toDelete, boolean deleteOnSampleUpdate) {
+    // Kept on the base with a runtime check (not moved to SampleTemplate): legacy behavior
+    // must throw for concrete Samples reached via SampleEntity-typed references.
+    if (!isTemplate()) {
+      throw new IllegalArgumentException(
+          "Cannot directly delete field from sample, only from template");
+    }
+    Optional<InventoryEntityField> fieldToDeleteOpt = getFieldById(toDelete.getId());
+    if (!fieldToDeleteOpt.isPresent()) {
+      throw new IllegalArgumentException(
+          "Trying to delete a field not belonging to current sample");
+    }
+    InventoryEntityField fieldToDelete = fieldToDeleteOpt.get();
+    fieldToDelete.setDeleted(true);
+    fieldToDelete.setDeleteOnSampleUpdate(deleteOnSampleUpdate);
+    refreshActiveFields();
+  }
+
+  public Optional<InventoryEntityField> getFieldById(Long id) {
+    return getFields().stream().filter(sf -> id != null && id.equals(sf.getId())).findFirst();
+  }
+
+  public List<InventoryEntityField> refreshActiveFields() {
+    activeFields = null;
+    return getActiveFields();
+  }
+
+  @NotNull
+  @Column(length = SUBSAMPLE_ALIAS_MAX_LENGTH)
+  private String getSubSampleName() {
+    return subSampleName;
+  }
+
+  @NotNull
+  @Column(length = SUBSAMPLE_ALIAS_MAX_LENGTH)
+  private String getSubSampleNamePlural() {
+    return subSampleNamePlural;
+  }
+
+  @Transient
+  public String getSubSampleAlias() {
+    return getSubSampleName();
+  }
+
+  @Transient
+  public String getSubSampleAliasPlural() {
+    return getSubSampleNamePlural();
+  }
+
+  @Transient
+  public void setSubSampleAliases(String alias, String aliasPlural) {
+    Validate.notBlank(alias, "SubSample alias cannot be blank");
+    Validate.notBlank(aliasPlural, "SubSample alias (plural) cannot be blank");
+    setSubSampleName(StringUtils.trim(alias));
+    setSubSampleNamePlural(StringUtils.trim(aliasPlural));
+  }
+
+  @Transient
+  public void setSubSampleAliases(SubSampleName name) {
+    setSubSampleName(name.getDisplayName());
+    setSubSampleNamePlural(name.getDisplayNamePlural());
+  }
+
+  @Embedded
+  @AttributeOverrides({
+      @AttributeOverride(name = "unitId", column = @Column(name = "quantityUnitId")),
+      @AttributeOverride(name = "numericValue", column = @Column(name = "quantityNumericValue", precision = 19, scale = 3))
+  })
+  public QuantityInfo getQuantityInfo() {
+    return quantityInfo;
+  }
+
+  /* marked 'protected' so concrete subclass methods are used by the code outside */
+  protected void setQuantityInfo(QuantityInfo quantityInfo) {
+    if (quantityInfo != null && quantityInfo.getUnitId() != null) {
+      if (BigDecimal.ZERO.compareTo(quantityInfo.getNumericValue()) > 0) {
+        throw new IllegalArgumentException(
+            "Trying to set negative record quantity: " + quantityInfo.getNumericValuePlainString());
+      }
+    }
+    this.quantityInfo = quantityInfo;
+  }
+
+  @Override
+  @Transient
+  public Integer getUnitId() {
+    return getQuantityInfo() == null ? null : getQuantityInfo().getUnitId();
+  }
+
+  @Override
+  @Transient
+  public BigDecimal getNumericValue() {
+    return getQuantityInfo() == null ? null : getQuantityInfo().getNumericValue();
+  }
+
+  /**
+   * Retrieve total quantity of the Sample. The total value is a sum of all subsample quantities,
+   * rounded to 3 fraction digits.
+   */
+  @Transient
+  public QuantityInfo getTotalQuantity() {
+    return this.getQuantityInfo();
+  }
+
+  /**
+   * Set total quantity of the Sample. Can be called only if sample has a single subsample, throws
+   * exception otherwise.
+   */
+  public void setTotalQuantity(QuantityInfo quantityInfo) {
+    if (hasExactlyOneSubSample()) {
+      this.setQuantityInfo(quantityInfo);
+      getActiveSubSamples().get(0).setQuantityInfo(quantityInfo);
+    } else {
+      throw new IllegalStateException(
+          "Can't save total quantity directly in Sample having multiple SubSamples");
+    }
+  }
+
+  public void recalculateTotalQuantity() {
+    QuantityUtils quantityUtils = new QuantityUtils();
+    List<QuantityInfo> subSampleQuantities = getActiveSubSamples().stream()
+        .filter(ss -> ss.getQuantity() != null)
+        .map(ss -> ss.getQuantity()).collect(Collectors.toList());
+
+    if (subSampleQuantities.isEmpty()) {
+      setQuantityInfo(null);
+      return;
+    }
+    if (subSampleQuantities.size() == 1) {
+      setQuantityInfo(subSampleQuantities.get(0));
+      return;
+    }
+
+    QuantityInfo totalQuantity = quantityUtils.sum(subSampleQuantities);
+    setQuantityInfo(totalQuantity);
+  }
+
+  /**
+   * @return the list of extra fields of this Sample, including deleted fields.
+   */
+  @OneToMany(mappedBy = "sample", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OrderBy(value = "id")
+  @Override
+  protected List<ExtraField> getExtraFields() {
+    return extraFields;
+  }
+
+  protected void setExtraFields(List<ExtraField> extraFields) {
+    this.extraFields = extraFields;
+    refreshActiveExtraFields();
+  }
+
+  /**
+   * @return the list of barcodes of this Sample, including deleted fields.
+   */
+  @OneToMany(mappedBy = "sample", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OrderBy(value = "id")
+  @Override
+  protected List<Barcode> getBarcodes() {
+    return barcodes;
+  }
+
+  protected void setBarcodes(List<Barcode> barcodes) {
+    this.barcodes = barcodes;
+    refreshActiveBarcodes();
+  }
+
+  @OneToMany(mappedBy = "sample", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OrderBy(value = "id")
+  @Override
+  protected List<DigitalObjectIdentifier> getIdentifiers() {
+    return identifiers;
+  }
+
+  protected void setIdentifiers(List<DigitalObjectIdentifier> identifiers) {
+    this.identifiers = identifiers;
+    refreshActiveIdentifiers();
+  }
+
+  /**
+   * @return the list of files attached to this Sample
+   */
+  @OneToMany(mappedBy = "sample", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OrderBy(value = "id")
+  protected List<InventoryFile> getFiles() {
+    return files;
+  }
+
+  protected void setFiles(List<InventoryFile> files) {
+    this.files = files;
+    refreshActiveAttachedFiles();
+  }
+
+  /**
+   * Adds subsample setting both sides of the relationship and refreshing active subsamples.
+   *
+   * @param subSampleToAdd
+   */
+  public void addSubSample(SubSample subSampleToAdd) {
+    this.subSamples.add(subSampleToAdd);
+    subSampleToAdd.setSample(this);
+    refreshActiveSubSamples();
+  }
+
+  /**
+   * Checks if provided alias singular and plural are equal to ones set in this Sample.
+   */
+  public boolean isSubSampleAliasEqualTo(String subSampleAlias, String subSampleAliasPlural) {
+    return getSubSampleAlias().equals(subSampleAlias) && getSubSampleAliasPlural().equals(
+        subSampleAliasPlural);
+  }
+
+}

--- a/src/main/java/com/researchspace/model/inventory/SampleTemplate.java
+++ b/src/main/java/com/researchspace/model/inventory/SampleTemplate.java
@@ -1,0 +1,114 @@
+package com.researchspace.model.inventory;
+
+import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdPrefix;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Transient;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.envers.Audited;
+import org.hibernate.search.annotations.Indexed;
+
+/**
+ * Represents RSpace Inventory Sample Template
+ */
+@Entity
+@DiscriminatorValue("SampleTemplate")
+@Audited
+@Getter
+@Setter
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
+@Indexed
+public class SampleTemplate extends SampleEntity {
+
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Reserved names for a Sample Template. Mirrors {@code TemplateModel.fieldNamesInUse} in the
+   * React UI: the template view is its own namespace. It reserves the base names plus the
+   * template-specific labels ({@code source}, {@code expiry date}, {@code subsample alias},
+   * {@code quantity units}, {@code fields}, {@code samples}) and, unlike a live Sample, does not
+   * reserve the sample-instance labels such as {@code sample template} or {@code subsamples}.
+   */
+  static final Set<String> SAMPLE_TEMPLATE_RESERVED_FIELD_NAMES = Collections.unmodifiableSet(
+      Stream.concat(
+              InventoryRecord.RESERVED_FIELD_NAMES.stream(),
+              Stream.of(
+                  "source",
+                  "expiry date",
+                  "subsample alias",
+                  "quantity units",
+                  "fields",
+                  "samples"))
+          .collect(Collectors.toSet()));
+
+  public SampleTemplate() {
+    super();
+  }
+
+  protected SampleTemplate(Sample originSample, User currentUser) {
+    this();
+    shallowCopyBasicFields(originSample, this);
+    originSample.copyQuantityInfoTo(this);
+    copy(originSample, this, this::defaultNameCopy, currentUser);
+  }
+
+  @Override
+  public SampleEntity copyToTemplate(User currentUser) {
+    throw new IllegalArgumentException("Only a Sample can be copied into a SampleTemplate");
+  }
+
+  @Override
+  public Sample copyFromTemplate(User currentUser) {
+    return new Sample(this, currentUser);
+  }
+
+  @Transient
+  @Override
+  public boolean isTemplate() {
+    return true;
+  }
+
+  @Transient
+  @Override
+  public InventoryRecordType getType() {
+    return InventoryRecordType.SAMPLE_TEMPLATE;
+  }
+
+  @Transient
+  @Override
+  public GlobalIdPrefix getGlobalIdPrefix() {
+    return GlobalIdPrefix.IT;
+  }
+
+  @Override
+  protected SampleEntity shallowCopy() {
+    SampleTemplate copy = new SampleTemplate();
+    shallowCopyBasicFields(copy);
+    copyQuantityInfoTo(copy);
+    return copy;
+  }
+
+  @Override
+  public SampleTemplate copy(User currentUser) {
+    return super.copy(this::defaultNameCopy, currentUser);
+  }
+
+  @Override
+  @Transient
+  public Set<String> getReservedFieldNames() {
+    return SAMPLE_TEMPLATE_RESERVED_FIELD_NAMES;
+  }
+
+  @Override
+  protected void assertCanStoreAttachments() {
+    throw new IllegalArgumentException("Sample Templates don't support file attachments yet");
+  }
+
+}

--- a/src/main/java/com/researchspace/model/inventory/SubSample.java
+++ b/src/main/java/com/researchspace/model/inventory/SubSample.java
@@ -68,14 +68,14 @@ public class SubSample extends MovableInventoryRecord implements Serializable, Q
 	@IndexedEmbedded(prefix = "fields.")
 	private List<SubSampleNote> notes = new ArrayList<>();
 
-	private Sample sample;
-	
+	private SampleEntity sample;
+
 	/* whether subsample was deleted implicitly as a part of sample deletion */
 	private boolean deletedOnSampleDeletion;
 
 	private QuantityInfo quantityInfo;
 
-	public SubSample(Sample sample) {
+	public SubSample(SampleEntity sample) {
 		setIconId(sample.getIconId());
 		setSample(sample);
 	}
@@ -236,8 +236,15 @@ public class SubSample extends MovableInventoryRecord implements Serializable, Q
 
 	@ManyToOne(cascade = { CascadeType.MERGE })
 	@JoinColumn(nullable = false)
-	public Sample getSample() {
+	public SampleEntity getSample() {
 		return sample;
+	}
+
+	@Override
+	@Transient
+	public SampleTemplate getLinkedSampleTemplate() {
+		SampleEntity parent = getSample();
+		return parent == null ? null : parent.getLinkedSampleTemplate();
 	}
 
 	@Transient

--- a/src/main/java/com/researchspace/model/inventory/field/InventoryEntityField.java
+++ b/src/main/java/com/researchspace/model/inventory/field/InventoryEntityField.java
@@ -8,7 +8,7 @@ import com.researchspace.model.field.ValidatingField;
 import com.researchspace.model.inventory.InstrumentEntity;
 import com.researchspace.model.inventory.InventoryFile;
 import com.researchspace.model.inventory.InventoryRecord;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
@@ -64,7 +64,7 @@ public abstract class InventoryEntityField implements Serializable, ValidatingFi
   private boolean deleteOnInstrumentUpdate;
   private boolean mandatory;
 
-  private Sample sample;
+  private SampleEntity sample;
   private InstrumentEntity instrumentEntity;
 
 
@@ -118,7 +118,7 @@ public abstract class InventoryEntityField implements Serializable, ValidatingFi
   }
   @ManyToOne
   @JoinColumn
-  public Sample getSample() {
+  public SampleEntity getSample() {
     return sample;
   }
 
@@ -409,8 +409,8 @@ public abstract class InventoryEntityField implements Serializable, ValidatingFi
    * Sets parent.
    */
   public void setInventoryRecord(InventoryRecord invRec) {
-    if (invRec instanceof Sample) {
-      sample = (Sample) invRec;
+    if (invRec instanceof SampleEntity) {
+      sample = (SampleEntity) invRec;
     } else if (invRec instanceof InstrumentEntity) {
       instrumentEntity = (InstrumentEntity) invRec;
     }

--- a/src/main/java/com/researchspace/model/record/DocumentFieldAttachmentInitializationPolicy.java
+++ b/src/main/java/com/researchspace/model/record/DocumentFieldAttachmentInitializationPolicy.java
@@ -6,7 +6,8 @@ import com.researchspace.model.elninventory.MaterialUsage;
 import com.researchspace.model.field.Field;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.MovableInventoryRecord;
-import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.inventory.field.InventoryEntityField;
 
@@ -61,12 +62,9 @@ public class DocumentFieldAttachmentInitializationPolicy extends DocumentInitial
 	}
 
 	private void initializeParentSampleTemplate(InventoryRecord invRec) {
-		Sample templateToInitialize = null;
-		if (invRec.isSample()) {
-			templateToInitialize = ((Sample) invRec).getSTemplate();
-		} else if (invRec.isSubSample()) {
-			templateToInitialize = ((SubSample) invRec).getSample().getSTemplate();
-		}
+		// getLinkedSampleTemplate() dispatches polymorphically through Hibernate proxies (Sample
+		// returns its template, SubSample delegates to its parent), so no unproxy/cast is needed.
+		SampleTemplate templateToInitialize = invRec.getLinkedSampleTemplate();
 		if (templateToInitialize != null) {
 			templateToInitialize.getImageFileProperty();
 		}
@@ -74,7 +72,7 @@ public class DocumentFieldAttachmentInitializationPolicy extends DocumentInitial
 
 	private void initializeParentSample(InventoryRecord invRec) {
 		if (invRec.isSubSample()) {
-			Sample parentSample = ((SubSample) invRec).getSample();
+			SampleEntity parentSample = ((SubSample) invRec).getSample();
 			for (InventoryEntityField sf : parentSample.getActiveFields()) {
 				sf.getAttachedFile();
 			}

--- a/src/main/java/com/researchspace/model/record/IRecordFactory.java
+++ b/src/main/java/com/researchspace/model/record/IRecordFactory.java
@@ -15,6 +15,8 @@ import com.researchspace.model.inventory.InstrumentTemplate;
 import com.researchspace.model.inventory.InventoryFile;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.inventory.field.ExtraField;
 import com.researchspace.model.units.QuantityInfo;
@@ -141,7 +143,7 @@ public interface IRecordFactory {
    * @param createdBy      creator and owner of the sample
    * @param sampleTemplate template to create sample from.
    */
-  Sample createSample(String name, User createdBy, Sample sampleTemplate);
+  Sample createSample(String name, User createdBy, SampleTemplate sampleTemplate);
 
   /**
    * Creates new Inventory Sample, with no fields and a default empty SubSample.
@@ -151,9 +153,25 @@ public interface IRecordFactory {
    */
   Sample createSample(String name, User createdBy);
 
-  SubSample createSubSample(String name, User createdBy, Sample sample);
+  /**
+   * Creates a new SubSample attached to the given {@link SampleEntity}
+   * (a {@link Sample}, or a {@link SampleTemplate} when building a template's default subsample).
+   *
+   * @param name subsample name
+   * @param createdBy creator and owner
+   * @param sample owning sample or template
+   */
+  SubSample createSubSample(String name, User createdBy, SampleEntity sample);
 
-  Sample createComplexSampleTemplate(String templateName, String desc, User createdBy);
+  SampleTemplate createComplexSampleTemplate(String templateName, String desc, User createdBy);
+
+  /**
+   * Creates new Inventory Sample Template, with no fields and a default empty SubSample.
+   *
+   * @param name      template name
+   * @param createdBy creator and owner of the template
+   */
+  SampleTemplate createSampleTemplate(String name, User createdBy);
 
   /**
    * Creates new Inventory instrument, with no fields

--- a/src/main/java/com/researchspace/model/record/RecordFactory.java
+++ b/src/main/java/com/researchspace/model/record/RecordFactory.java
@@ -30,6 +30,8 @@ import com.researchspace.model.inventory.InstrumentTemplate;
 import com.researchspace.model.inventory.InventoryFile;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.inventory.SubSampleName;
 import com.researchspace.model.inventory.field.ExtraField;
@@ -335,15 +337,14 @@ public class RecordFactory implements IRecordFactory {
   }
 
   @Override
-  public Sample createComplexSampleTemplate(String templateName, String desc, User createdBy) {
+  public SampleTemplate createComplexSampleTemplate(String templateName, String desc, User createdBy) {
 
     Calendar formDate = Calendar.getInstance();
     formDate.set(2020, 4, 4, 6, 55, 15);
 
-    Sample template = createSample(templateName, createdBy);
-    template.setTemplate(true);
+    SampleTemplate template = createSampleTemplate(templateName, createdBy);
     template.setSubSampleAliases(SubSampleName.ALIQUOT);
-    template.setDescription("A template with all field types");
+    template.setDescription(desc);
     template.setStorageTempMin(QuantityInfo.of(3, RSUnitDef.CELSIUS));
     template.setStorageTempMax(QuantityInfo.of(10, RSUnitDef.CELSIUS));
 
@@ -417,6 +418,24 @@ public class RecordFactory implements IRecordFactory {
     return sample;
   }
 
+  @Override
+  public SampleTemplate createSampleTemplate(String name, User createdBy) {
+    checkArgs(name, createdBy);
+
+    SampleTemplate template = new SampleTemplate();
+    template.setName(abbreviate(trim(name), BaseRecord.DEFAULT_VARCHAR_LENGTH));
+    template.setCreatedBy(createdBy.getUsername());
+    template.setOwner(createdBy);
+    template.setModifiedBy(createdBy.getUsername(), modifiedByStrategy);
+    template.setSubSampleAliases(SubSampleName.ALIQUOT);
+    List<SubSample> defaultSubSampleList = new ArrayList<>();
+    defaultSubSampleList.add(createSubSample(template.getName(), createdBy, template));
+    template.setSubSamples(defaultSubSampleList);
+    template.setDefaultUnitId(RSUnitDef.MILLI_LITRE.getId());
+
+    return template;
+  }
+
 
   @Override
   public Instrument createInstrument(String name, User createdBy,
@@ -445,9 +464,9 @@ public class RecordFactory implements IRecordFactory {
 
 
   @Override
-  public Sample createSample(String name, User createdBy, Sample sampleTemplate) {
+  public Sample createSample(String name, User createdBy, SampleTemplate sampleTemplate) {
     checkArgs(name, createdBy);
-    Validate.isTrue(sampleTemplate.isTemplate(), "requires sample to be a template");
+    Validate.notNull(sampleTemplate, "sampleTemplate must not be null");
     Sample sample = sampleTemplate.copyFromTemplate(createdBy);
     sample.setName(name);
     sample.setModifiedBy(createdBy.getUsername(), modifiedByStrategy);
@@ -464,7 +483,7 @@ public class RecordFactory implements IRecordFactory {
   }
 
   @Override
-  public SubSample createSubSample(String name, User createdBy, Sample sample) {
+  public SubSample createSubSample(String name, User createdBy, SampleEntity sample) {
     checkArgs(name, createdBy);
 
     SubSample subSample = new SubSample(sample);
@@ -475,14 +494,17 @@ public class RecordFactory implements IRecordFactory {
     return subSample;
   }
 
-  private QuantityInfo getDefaultQuantityForNewSubSample(Sample sample) {
+  private QuantityInfo getDefaultQuantityForNewSubSample(SampleEntity sample) {
     RSUnitDef subSampleUnit;
-    if (sample.getSTemplate() != null && sample.getSTemplate().getDefaultUnitId() != null) {
-      subSampleUnit = RSUnitDef.getUnitById(sample.getSTemplate().getDefaultUnitId());
+    // getLinkedSampleTemplate() dispatches polymorphically through any Hibernate proxy, so no
+    // unproxy/cast is needed (returns null for a template or a sample with no template).
+    SampleTemplate template = sample.getLinkedSampleTemplate();
+    if (template != null && template.getDefaultUnitId() != null) {
+      subSampleUnit = RSUnitDef.getUnitById(template.getDefaultUnitId());
     } else if (sample.getQuantityInfo() != null) {
       subSampleUnit = RSUnitDef.getUnitById(sample.getQuantityInfo().getUnitId());
     } else {
-      subSampleUnit = RSUnitDef.MILLI_LITRE; // default for basic sample
+      subSampleUnit = RSUnitDef.MILLI_LITRE; // fallback default when no template or quantity info is available
     }
     return QuantityInfo.of(BigDecimal.ONE, subSampleUnit);
   }

--- a/src/main/java/com/researchspace/model/stoichiometry/StoichiometryInventoryLink.java
+++ b/src/main/java/com/researchspace/model/stoichiometry/StoichiometryInventoryLink.java
@@ -1,12 +1,10 @@
 package com.researchspace.model.stoichiometry;
 
+import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.InventoryRecordConnectedEntity;
 import javax.persistence.Access;
 import javax.persistence.AccessType;
-import javax.persistence.AttributeOverride;
-import javax.persistence.AttributeOverrides;
 import javax.persistence.Column;
-import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -14,9 +12,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import javax.validation.ConstraintViolationException;
-
-import com.researchspace.model.inventory.Sample;
-import com.researchspace.model.units.QuantityInfo;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.envers.Audited;
@@ -52,11 +47,11 @@ public class StoichiometryInventoryLink extends InventoryRecordConnectedEntity {
   @Override
   public void validateBeforeSave() {
     super.validateBeforeSave();
-    if (getInventoryRecord() instanceof Sample){
-      Sample sample = (Sample) getInventoryRecord();
-      if(sample.isTemplate()){
-        throw new ConstraintViolationException("Cannot link stoichiometry to sample template", null);
-      }
+    // isSampleTemplate() rather than instanceof: a lazily-loaded reference is a proxy typed to
+    // the abstract root (never the concrete subclass), but virtual dispatch reaches the real type
+    InventoryRecord invRec = getInventoryRecord();
+    if (invRec != null && invRec.isSampleTemplate()) {
+      throw new ConstraintViolationException("Cannot link stoichiometry to sample template", null);
     }
   }
 }

--- a/src/test/java/com/researchspace/model/inventory/InventoryRecordReservedFieldNamesTest.java
+++ b/src/test/java/com/researchspace/model/inventory/InventoryRecordReservedFieldNamesTest.java
@@ -49,8 +49,7 @@ class InventoryRecordReservedFieldNamesTest {
 
   @Test
   void sampleTemplateReservedFieldNames() {
-    Sample template = new Sample();
-    template.setTemplate(true);
+    SampleTemplate template = new SampleTemplate();
     assertEquals(
         union(
             BASE_RESERVED,
@@ -81,8 +80,7 @@ class InventoryRecordReservedFieldNamesTest {
     allSets.addAll(new Container(Container.ContainerType.LIST).getReservedFieldNames());
     allSets.addAll(new SubSample().getReservedFieldNames());
     allSets.addAll(new Sample().getReservedFieldNames());
-    Sample template = new Sample();
-    template.setTemplate(true);
+    SampleTemplate template = new SampleTemplate();
     allSets.addAll(template.getReservedFieldNames());
     allSets.addAll(new Instrument().getReservedFieldNames());
     allSets.addAll(new InstrumentTemplate().getReservedFieldNames());
@@ -166,8 +164,7 @@ class InventoryRecordReservedFieldNamesTest {
   @ParameterizedTest
   @ValueSource(strings = {"Subsample Alias", "subsample alias", "SUBSAMPLE ALIAS", "Quantity Units"})
   void sampleTemplateRejectsTemplateLabelInAnyCase(String fieldName) {
-    Sample template = new Sample();
-    template.setTemplate(true);
+    SampleTemplate template = new SampleTemplate();
     ExtraTextField field = new ExtraTextField();
     field.setName(fieldName);
 

--- a/src/test/java/com/researchspace/model/inventory/SampleTemplateTest.java
+++ b/src/test/java/com/researchspace/model/inventory/SampleTemplateTest.java
@@ -1,0 +1,243 @@
+package com.researchspace.model.inventory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.researchspace.model.FileProperty;
+import com.researchspace.model.FileStoreRoot;
+import com.researchspace.model.User;
+import com.researchspace.model.core.GlobalIdPrefix;
+import com.researchspace.model.inventory.field.InventoryEntityField;
+import com.researchspace.model.inventory.field.InventoryTextField;
+import com.researchspace.model.record.RecordFactory;
+import com.researchspace.model.record.TestFactory;
+import com.researchspace.model.units.RSUnitDef;
+import java.io.File;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class SampleTemplateTest {
+
+  private SampleTemplate template;
+  private User anyUser;
+
+  @BeforeEach
+  public void setUp() {
+    anyUser = TestFactory.createAnyUser("any");
+    RecordFactory rf = new RecordFactory();
+    template = rf.createSampleTemplate("test template", anyUser);
+    template.setId(6L);
+  }
+
+  @Test
+  public void testInitialProperties() {
+    assertNotNull(template.getModificationDate());
+    assertNotNull(template.getCreationDate());
+    assertFalse(template.isDeleted());
+    assertTrue(template.isTemplate());
+    assertEquals(InventoryRecord.InventoryRecordType.SAMPLE_TEMPLATE, template.getType());
+    assertTrue(template.isSampleTemplate());
+    assertFalse(template.isSample());
+    assertEquals("IT" + template.getId(), template.getOid().toString());
+    assertEquals("IT" + template.getId() + "v1", template.getOidWithVersion().toString());
+    // default subsample exists after factory creation
+    assertEquals(1, template.getSubSamples().size());
+    assertEquals(1, template.getActiveSubSamplesCount());
+    // default subsample alias
+    assertEquals(SubSampleName.ALIQUOT.getDisplayName(), template.getSubSampleAlias());
+    // default unit
+    assertEquals(RSUnitDef.MILLI_LITRE.getId(), template.getDefaultUnitId());
+  }
+
+  @Test
+  @DisplayName("Quantifiable accessors return null when no quantity is set")
+  public void quantityAccessorsReturnNullWhenNoQuantity() {
+    // a SampleEntity may have a null quantityInfo (a template has none; recalculateTotalQuantity
+    // also nulls it on a Sample with no subsample quantities). getUnitId()/getNumericValue() must
+    // return null in that case rather than NPE when the entity is treated as a Quantifiable.
+    assertNull(template.getQuantityInfo());
+    assertNull(template.getUnitId());
+    assertNull(template.getNumericValue());
+  }
+
+  @Test
+  @DisplayName("getLinkedSampleTemplate is null for a template and a template-less sample")
+  public void getLinkedSampleTemplateIsNullWithoutALinkedTemplate() {
+    assertNull(template.getLinkedSampleTemplate());
+    assertNull(new Sample().getLinkedSampleTemplate());
+  }
+
+  @Test
+  @DisplayName("getLinkedSampleTemplate resolves the template for a sample and its subsamples")
+  public void getLinkedSampleTemplateResolvesForSampleAndSubSamples() {
+    Sample sampleFromTemplate = template.copyFromTemplate(anyUser);
+    // Sample returns its own template; SubSample delegates to its parent sample - both via
+    // polymorphic dispatch, so they resolve through a Hibernate proxy with no unproxy/cast
+    assertEquals(template, sampleFromTemplate.getLinkedSampleTemplate());
+    assertEquals(template, sampleFromTemplate.getSubSamples().get(0).getLinkedSampleTemplate());
+  }
+
+  @Test
+  @DisplayName("Use OID to distinguish sample templates from samples")
+  public void globalId() {
+    assertTrue(template.getGlobalIdentifier().startsWith("IT"));
+    assertEquals(GlobalIdPrefix.IT, template.getOid().getPrefix());
+
+    Sample sampleFromTemplate = template.copyFromTemplate(anyUser);
+    sampleFromTemplate.setId(7L);
+
+    assertTrue(sampleFromTemplate.getGlobalIdentifier().startsWith("SA"));
+    assertEquals(GlobalIdPrefix.SA, sampleFromTemplate.getOid().getPrefix());
+  }
+
+  @Test
+  @DisplayName("Make sample from template")
+  public void copyFromTemplate() {
+    template.increaseVersion();
+
+    Sample copiedSample = template.copyFromTemplate(anyUser);
+    assertFalse(copiedSample.isTemplate());
+    assertEquals(template, copiedSample.getSTemplate());
+    assertEquals(template.getVersion(), copiedSample.getSTemplateLinkedVersion());
+    assertEquals(1L, copiedSample.getVersion());
+    assertEquals(1, copiedSample.getSubSamples().get(0).getVersion());
+    copiedSample.setId(7L);
+    assertTrue(copiedSample.getGlobalIdentifier().startsWith("SA"));
+  }
+
+  @Test
+  @DisplayName("copyFromTemplate copies fields with templateField links set")
+  public void copyFromTemplateFieldLinks() {
+    InventoryTextField field = new InventoryTextField("material");
+    field.setId(1L);
+    template.addSampleField(field);
+
+    Sample copiedSample = template.copyFromTemplate(anyUser);
+    assertEquals(1, copiedSample.getActiveFields().size());
+    InventoryEntityField copiedField = copiedSample.getActiveFields().get(0);
+    assertEquals("material", copiedField.getName());
+    // template field link should point back to the original template field
+    assertEquals(field, copiedField.getTemplateField());
+  }
+
+  @Test
+  public void copy() {
+    addField(template, buildTextField(1L, 1, "manufacturer", "Acme"));
+
+    SampleTemplate copied = template.copy(anyUser);
+    assertTrue(copied.isTemplate());
+    assertNull(copied.getGlobalIdentifier());
+    assertEquals(template.getName() + "_COPY", copied.getName());
+    assertEquals(1, copied.getActiveFields().size());
+    assertEquals("manufacturer", copied.getActiveFields().get(0).getName());
+    assertEquals("Acme", copied.getActiveFields().get(0).getFieldData());
+    // template copy is NOT linked to the original via sTemplate
+    // (the copy is a standalone template, not a sample instance)
+  }
+
+  @Test
+  @DisplayName("SampleTemplate cannot be copied to template")
+  public void copyToTemplateNotAllowed() {
+    IllegalArgumentException iae =
+        assertThrows(IllegalArgumentException.class, () -> template.copyToTemplate(anyUser));
+    assertEquals("Only a Sample can be copied into a SampleTemplate", iae.getMessage());
+  }
+
+  @Test
+  @DisplayName("Reserved field names differ from a plain Sample's")
+  public void reservedFieldNames() {
+    Sample plainSample = new Sample();
+
+    // Template does NOT have the sample-specific fields "sample template", "storage temperature",
+    // "total quantity", "subsamples" but DOES have template-specific ones
+    assertFalse(template.getReservedFieldNames().contains("sample template"));
+    assertFalse(template.getReservedFieldNames().contains("storage temperature"));
+    assertFalse(template.getReservedFieldNames().contains("total quantity"));
+    assertFalse(template.getReservedFieldNames().contains("subsamples"));
+    assertTrue(template.getReservedFieldNames().contains("subsample alias"));
+    assertTrue(template.getReservedFieldNames().contains("quantity units"));
+    assertTrue(template.getReservedFieldNames().contains("fields"));
+    assertTrue(template.getReservedFieldNames().contains("samples"));
+
+    // Plain Sample has the sample-specific fields but not the template-specific ones
+    assertTrue(plainSample.getReservedFieldNames().contains("sample template"));
+    assertTrue(plainSample.getReservedFieldNames().contains("storage temperature"));
+    assertTrue(plainSample.getReservedFieldNames().contains("total quantity"));
+    assertTrue(plainSample.getReservedFieldNames().contains("subsamples"));
+    assertFalse(plainSample.getReservedFieldNames().contains("subsample alias"));
+    assertFalse(plainSample.getReservedFieldNames().contains("quantity units"));
+    assertFalse(plainSample.getReservedFieldNames().contains("fields"));
+    assertFalse(plainSample.getReservedFieldNames().contains("samples"));
+  }
+
+  @Test
+  @DisplayName("Direct addAttachedFile on a template throws IllegalArgumentException")
+  public void directAttachmentOnTemplateThrows() {
+    IllegalArgumentException iae =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> template.addAttachedFile(new InventoryFile(null, null)));
+    assertEquals("Sample Templates don't support file attachments yet", iae.getMessage());
+  }
+
+  @Test
+  @DisplayName("Duplicating a template with an attachment carries the attachment to the copy")
+  public void copyTemplateWithAttachmentCarriesAttachment() throws IOException {
+    // getFiles().add() bypasses doAddAttachedFile(), so the inventoryRecord link and
+    // the active-files cache must be set up manually - the same state shallowCopyBasicFields() produces.
+    InventoryFile invFile = buildAttachment(anyUser);
+    invFile.setInventoryRecord(template);
+    template.getFiles().add(invFile);
+    template.refreshActiveAttachedFiles();
+
+    assertEquals(1, template.getAttachedFiles().size());
+
+    SampleTemplate copied = template.copy(anyUser);
+    assertEquals(1, copied.getAttachedFiles().size(), "attachment should be carried to the copy");
+  }
+
+  @Test
+  @DisplayName("copyToTemplate on a sample with an attachment carries the attachment to the template")
+  public void copyToTemplateWithAttachmentCarriesAttachment() throws IOException {
+    Sample sample = TestFactory.createBasicSampleInContainer(anyUser);
+    InventoryFile invFile = buildAttachment(anyUser);
+    sample.addAttachedFile(invFile);
+    assertEquals(1, sample.getAttachedFiles().size());
+
+    SampleTemplate derivedTemplate = sample.copyToTemplate(anyUser);
+    assertEquals(
+        1,
+        derivedTemplate.getAttachedFiles().size(),
+        "attachment from sample should be carried to the derived template");
+  }
+
+  // -- helpers --
+
+  private InventoryTextField buildTextField(
+      Long id, Integer columnIndex, String name, String data) {
+    InventoryTextField field = new InventoryTextField(name);
+    field.setId(id);
+    field.setColumnIndex(columnIndex);
+    field.setFieldData(data);
+    return field;
+  }
+
+  private void addField(SampleEntity sampleEntity, InventoryEntityField field) {
+    field.setInventoryRecord(sampleEntity);
+    sampleEntity.getFields().add(field);
+    sampleEntity.refreshActiveFieldsAndColumnIndex();
+  }
+
+  private InventoryFile buildAttachment(User owner) throws IOException {
+    FileStoreRoot fsRoot = new FileStoreRoot("/some/path");
+    FileProperty fp =
+        TestFactory.createAFileProperty(File.createTempFile("att", ".txt"), owner, fsRoot);
+    return new InventoryFile("test-attachment.txt", fp);
+  }
+}

--- a/src/test/java/com/researchspace/model/inventory/SampleTest.java
+++ b/src/test/java/com/researchspace/model/inventory/SampleTest.java
@@ -47,6 +47,9 @@ public class SampleTest {
 		assertNotNull(sample.getCreationDate());
 		assertNotNull(sample.getSampleSource());
 		assertFalse(sample.isDeleted());
+		assertEquals(InventoryRecord.InventoryRecordType.SAMPLE, sample.getType());
+		assertTrue(sample.isSample());
+		assertFalse(sample.isSampleTemplate());
 		assertEquals(1, sample.getAttachedFiles().size());
 		assertEquals(1, sample.getActiveBarcodes().size());
 		assertEquals(1, sample.getActiveSubSamplesCount());
@@ -78,7 +81,7 @@ public class SampleTest {
 				"activeExtraFields", "extraFields", "activeBarcodes", "barcodes", "activeIdentifiers", "identifiers",
 				"sample", "editInfo", "attachedFiles", "files");
 		ModelTestUtils.assertCopiedFieldsAreEqual(copy, sample, toIgnore,
-				TransformerUtils.toList(Sample.class, InventoryRecord.class));
+				TransformerUtils.toList(Sample.class, SampleEntity.class, InventoryRecord.class));
 		assertNull(copy.getGlobalIdentifier());
 		assertNotNull(copy.getImageFileProperty());
 		assertNotNull(copy.getThumbnailFileProperty());
@@ -103,7 +106,7 @@ public class SampleTest {
 		assertTrue(sample.getGlobalIdentifier().startsWith("SA"));
 		assertEquals(sample.getOid().getPrefix(), GlobalIdPrefix.SA);
 		
-		Sample template = sample.copyToTemplate(anyUser);
+		SampleTemplate template = sample.copyToTemplate(anyUser);
 		template.setId(6L);
 		assertTrue(template.getGlobalIdentifier().startsWith("IT"));
 		assertTrue(template.getOid().getPrefix().equals(GlobalIdPrefix.IT));
@@ -113,7 +116,7 @@ public class SampleTest {
 
 	@Test
 	public void subSampleAlias() {
-		Sample template = sample.copyToTemplate(anyUser);
+		SampleTemplate template = sample.copyToTemplate(anyUser);
 		template.setSubSampleAliases("alias", " aliases ");
 		assertEquals("alias", template.getSubSampleAlias());
 		assertEquals("aliases", template.getSubSampleAliasPlural()); // trimmed
@@ -155,7 +158,7 @@ public class SampleTest {
 	@Test
 	@DisplayName("Make template from sample")
 	public void copyToTemplate() {
-		Sample template = sample.copyToTemplate(anyUser);
+		SampleTemplate template = sample.copyToTemplate(anyUser);
 		assertTrue(template.isTemplate());
 		
 		// can assign a sample template fine 
@@ -164,10 +167,11 @@ public class SampleTest {
 		// can copy a sample, but can't sample from as if it was a template 
 		Sample justACopy = sample.copy(anyUser);
 		assertFalse(justACopy.isTemplate());
-		assertThrows(IllegalArgumentException.class, ()-> justACopy.copyFromTemplate(anyUser));
+		IllegalStateException ise = assertThrows(IllegalStateException.class, ()-> justACopy.copyFromTemplate(anyUser));
+		assertEquals("Only a SampleTemplate can be used to copy from a template", ise.getMessage());
 		
 		// can copy a template
-		Sample newTemplate = justACopy.copyToTemplate(anyUser);
+		SampleTemplate newTemplate = justACopy.copyToTemplate(anyUser);
 		assertTrue(newTemplate.isTemplate());
 	}
 	
@@ -175,7 +179,7 @@ public class SampleTest {
 	@DisplayName("Make sample from template")
 	public void copyFromTemplate() {
 		//make a template
-		Sample template = sample.copyToTemplate(anyUser);
+		SampleTemplate template = sample.copyToTemplate(anyUser);
 
 		Sample newSample = template.copyFromTemplate(anyUser);
 		assertFalse(newSample.isTemplate());
@@ -189,7 +193,7 @@ public class SampleTest {
 	@DisplayName("Update sample to latest template definition")
 	public void updateSampleToLatestTemplateDefinition() {
 		// make a template, and a new sample out of it
-		Sample template = sample.copyToTemplate(anyUser);
+		SampleTemplate template = sample.copyToTemplate(anyUser);
 		Sample newSample = template.copyFromTemplate(anyUser);
 		assertEquals(SubSampleName.ALIQUOT.getDisplayName(), newSample.getSubSampleAlias());
 		assertEquals(0, newSample.getActiveFields().size());
@@ -235,8 +239,8 @@ public class SampleTest {
 	@Test
 	public void checkTemplateOperations() throws Exception {
 		// make a template
-		Sample template = sample.copyToTemplate(anyUser);
-		
+		SampleTemplate template = sample.copyToTemplate(anyUser);
+
 		// try attaching a file to workbench
 		IllegalArgumentException iae = assertThrows(IllegalArgumentException.class, 
 				() -> template.addAttachedFile(new InventoryFile(null, null)));
@@ -247,7 +251,7 @@ public class SampleTest {
 	@DisplayName("Delete sample template field")
 	public void deleteSampleTemplateField() {
 		
-		Sample template = sample.copyToTemplate(anyUser);
+		SampleTemplate template = sample.copyToTemplate(anyUser);
 
 		// no fields to start with
 		assertEquals(0, template.getFields().size());

--- a/src/test/java/com/researchspace/model/inventory/field/InventoryEntityFieldTest.java
+++ b/src/test/java/com/researchspace/model/inventory/field/InventoryEntityFieldTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.researchspace.model.inventory.InventoryFile;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -381,7 +382,7 @@ class InventoryEntityFieldTest {
 		assertTrue(field.validate(value).hasErrorMessages());
 		
 		// but if field is a part of the sample template, then it accepts blank value fine
-		parentSample.setTemplate(true);
+		field.setInventoryRecord(new SampleTemplate());
 		assertFalse(field.validate(value).hasErrorMessages());
 	}
 

--- a/src/test/java/com/researchspace/model/record/RecordFactoryTest.java
+++ b/src/test/java/com/researchspace/model/record/RecordFactoryTest.java
@@ -14,8 +14,12 @@ import com.researchspace.model.field.FieldType;
 import com.researchspace.model.inventory.Instrument;
 import com.researchspace.model.inventory.InstrumentTemplate;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
+import com.researchspace.model.inventory.SubSample;
+import com.researchspace.model.inventory.SubSampleName;
 import com.researchspace.model.inventory.field.ExtraField;
 import com.researchspace.model.inventory.field.ExtraLinkField;
+import com.researchspace.model.units.RSUnitDef;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -149,5 +153,74 @@ public class RecordFactoryTest {
 		assertEquals(template.getVersion(), fromTemplate.getTemplateLinkedVersion());
 	}
 
+	@Test
+	public void testCreateSampleTemplate() {
+		SampleTemplate template = factoryAPI.createSampleTemplate("my template", user);
+		assertNotNull(template);
+		assertEquals("my template", template.getName());
+		assertTrue(template.isTemplate());
+		// default subsample alias is ALIQUOT
+		assertEquals(SubSampleName.ALIQUOT.getDisplayName(), template.getSubSampleAlias());
+		// one default subsample
+		assertEquals(1, template.getSubSamples().size());
+		assertEquals(1, template.getActiveSubSamplesCount());
+		// default unit is MILLI_LITRE
+		assertEquals(RSUnitDef.MILLI_LITRE.getId(), template.getDefaultUnitId());
+		// owner and createdBy set
+		assertEquals(user, template.getOwner());
+		assertEquals(user.getUsername(), template.getCreatedBy());
+	}
+
+	@Test
+	public void testCreateSampleFromTemplate() {
+		SampleTemplate template = factoryAPI.createSampleTemplate("tmpl", user);
+
+		Sample sample = factoryAPI.createSample("derived sample", otherUser, template);
+
+		assertNotNull(sample);
+		assertEquals("derived sample", sample.getName());
+		assertFalse(sample.isTemplate());
+		assertEquals(template, sample.getSTemplate());
+		assertEquals(template.getVersion(), sample.getSTemplateLinkedVersion());
+		assertEquals(otherUser, sample.getOwner());
+		assertEquals(otherUser.getUsername(), sample.getCreatedBy());
+		assertEquals(otherUser.getUsername(), sample.getModifiedBy());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testCreateSampleFromTemplateRejectsNullTemplate() {
+		factoryAPI.createSample("fail", user, null);
+	}
+
+	@Test
+	public void testCreateSubSampleUsesSampleTemplateDefaultUnit() {
+		SampleTemplate template = factoryAPI.createSampleTemplate("tmpl", user);
+		template.setDefaultUnitId(RSUnitDef.GRAM.getId());
+		Sample sample = factoryAPI.createSample("derived", otherUser, template);
+
+		SubSample subSample = factoryAPI.createSubSample("ss", otherUser, sample);
+
+		// a Sample backed by a template adopts the template's default unit
+		assertEquals(RSUnitDef.GRAM.getId(), subSample.getQuantity().getUnitId());
+	}
+
+	@Test
+	public void testCreateSubSampleForTemplateDoesNotCastToSample() {
+		SampleTemplate template = factoryAPI.createSampleTemplate("tmpl", user);
+
+		// a SampleTemplate is a SampleEntity but NOT a Sample: createSubSample must not
+		// attempt a Sample cast, and falls back to the default unit with no quantity info
+		SubSample subSample = factoryAPI.createSubSample("ss", user, template);
+
+		assertNotNull(subSample.getQuantity());
+		assertEquals(RSUnitDef.MILLI_LITRE.getId(), subSample.getQuantity().getUnitId());
+	}
+
+	@Test
+	public void createComplexSampleTemplateUsesProvidedDescription() {
+		SampleTemplate template =
+				factoryAPI.createComplexSampleTemplate("tmpl", "my custom description", user);
+		assertEquals("my custom description", template.getDescription());
+	}
 
 }

--- a/src/test/java/com/researchspace/model/record/TestFactory.java
+++ b/src/test/java/com/researchspace/model/record/TestFactory.java
@@ -32,6 +32,7 @@ import com.researchspace.model.inventory.InventoryFile;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.Sample;
 import com.researchspace.model.inventory.SampleSource;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.inventory.field.ExtraNumberField;
 import com.researchspace.model.inventory.field.ExtraTextField;
@@ -467,7 +468,7 @@ public class TestFactory {
 
   public static Sample createComplexSampleInContainer(User user) {
     Container cont = rf.createListContainer("test", user);
-    Sample sampleTemplate = rf.createComplexSampleTemplate("complex template", "for tests", user);
+    SampleTemplate sampleTemplate = rf.createComplexSampleTemplate("complex template", "for tests", user);
     Sample sample = rf.createSample("test complex sample", user, sampleTemplate);
     sample.getSubSamples().get(0).moveToNewParent(cont);
     return sample;

--- a/src/test/java/com/researchspace/model/test/HibernateAuditTest.java
+++ b/src/test/java/com/researchspace/model/test/HibernateAuditTest.java
@@ -1,11 +1,18 @@
 package com.researchspace.model.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
+import com.researchspace.model.audit.AuditedEntity;
+import com.researchspace.model.inventory.Container;
 import com.researchspace.model.inventory.DigitalObjectIdentifier;
+import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleTemplate;
+import com.researchspace.model.inventory.SubSample;
+import com.researchspace.model.inventory.field.ExtraTextField;
+import com.researchspace.model.record.TestFactory;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.envers.AuditReader;
@@ -15,13 +22,6 @@ import org.hibernate.envers.RevisionType;
 import org.hibernate.envers.query.AuditEntity;
 import org.hibernate.envers.query.AuditQuery;
 import org.junit.jupiter.api.Test;
-
-import com.researchspace.model.audit.AuditedEntity;
-import com.researchspace.model.inventory.Container;
-import com.researchspace.model.inventory.Sample;
-import com.researchspace.model.inventory.SubSample;
-import com.researchspace.model.inventory.field.ExtraTextField;
-import com.researchspace.model.record.TestFactory;
 
 /**
  * Tests audit tables. 
@@ -109,6 +109,51 @@ class HibernateAuditTest extends HibernateTest {
 	private void saveSampleInContainer(Sample sample) {
 		dao.save(sample.getSubSamples().get(0).getParentContainer(), Container.class);
 		sample = dao.save(sample, Sample.class);
+	}
+
+	@Test
+	public void searchSampleTemplateHistory() {
+
+		// save new sample template
+		SampleTemplate template = rf.createSampleTemplate("template uniquename", testUser);
+		template = dao.save(template, SampleTemplate.class);
+
+		// update template name
+		template.setName("updated template name");
+		template = dao.update(template, SampleTemplate.class);
+
+		Long templateId = template.getId();
+
+		Session session = null;
+		Transaction transaction = null;
+		try {
+			session = sf.getCurrentSession();
+			transaction = session.getTransaction();
+			transaction.begin();
+
+			List<AuditedEntity<SampleTemplate>> templateHistory = getRevisionsForObject(SampleTemplate.class, templateId);
+			assertEquals(2, templateHistory.size());
+			assertInstanceOf(SampleTemplate.class, templateHistory.get(0).getEntity());
+			assertInstanceOf(SampleTemplate.class, templateHistory.get(1).getEntity());
+			assertEquals("template uniquename", templateHistory.get(0).getEntity().getName());
+			assertEquals("updated template name", templateHistory.get(1).getEntity().getName());
+
+			// Envers filters revisions by discriminator: no Sample revisions exist for the template id
+			List<AuditedEntity<Sample>> sampleHistory = getRevisionsForObject(Sample.class, templateId);
+			assertEquals(0, sampleHistory.size());
+
+			transaction.commit();
+
+		} catch (Exception e) {
+			if (transaction != null) {
+				transaction.rollback();
+			}
+			throw e;
+		} finally {
+			if (session != null) {
+				session.close();
+			}
+		}
 	}
 
 	@Test

--- a/src/test/java/com/researchspace/model/test/HibernateSandboxTest.java
+++ b/src/test/java/com/researchspace/model/test/HibernateSandboxTest.java
@@ -35,6 +35,8 @@ import com.researchspace.model.inventory.InstrumentTemplate;
 import com.researchspace.model.inventory.InventoryFile;
 import com.researchspace.model.inventory.InventoryRecord.InventorySharingMode;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.inventory.SubSampleNote;
 import com.researchspace.model.inventory.field.ExtraField;
@@ -73,6 +75,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.validation.ConstraintViolationException;
 import org.hibernate.LazyInitializationException;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -275,6 +279,54 @@ class HibernateSandboxTest extends HibernateTest {
     assertInstanceOf(InstrumentTemplate.class, loaded);
 		assertTrue(loaded.isTemplate());
 		assertEquals(GlobalIdPrefix.NT, loaded.getOid().getPrefix());
+	}
+
+	@Test
+	@DisplayName("Persist and reload SampleTemplate discriminator")
+	void persistSampleTemplateDiscriminator() {
+		User user = createAndSaveAnyUser();
+		SampleTemplate template = rf.createSampleTemplate("test sample template", user);
+		template = dao.save(template, SampleTemplate.class);
+
+		SampleEntity loadedTemplate = dao.load(template.getId(), SampleEntity.class);
+		assertInstanceOf(SampleTemplate.class, loadedTemplate);
+		assertTrue(loadedTemplate.isTemplate());
+		assertEquals(GlobalIdPrefix.IT, loadedTemplate.getOid().getPrefix());
+
+		Sample sample = TestFactory.createBasicSampleInContainer(user);
+		sample = saveSampleInContainer(sample);
+		SampleEntity loadedSample = dao.load(sample.getId(), SampleEntity.class);
+		assertInstanceOf(Sample.class, loadedSample);
+		assertFalse(loadedSample.isTemplate());
+		assertEquals(GlobalIdPrefix.SA, loadedSample.getOid().getPrefix());
+
+		// inserts write the DTYPE discriminator: "SampleTemplate" for the template, "Sample" otherwise
+		assertEquals("SampleTemplate", readDiscriminatorValue(template.getId()));
+		assertEquals("Sample", readDiscriminatorValue(sample.getId()));
+	}
+
+	private String readDiscriminatorValue(Long id) {
+		Transaction transaction = null;
+		Session session = null;
+		try {
+			session = sf.openSession();
+			transaction = session.beginTransaction();
+			Object discriminatorValue = session
+					.createNativeQuery("select DTYPE from Sample where id = :id")
+					.setParameter("id", id)
+					.getSingleResult();
+			transaction.commit();
+			return (String) discriminatorValue;
+		} catch (Exception e) {
+			if (transaction != null) {
+				transaction.rollback();
+			}
+			throw e;
+		} finally {
+			if (session != null) {
+				session.close();
+			}
+		}
 	}
 
 	@Test

--- a/src/test/java/com/researchspace/model/test/HibernateSearchTest.java
+++ b/src/test/java/com/researchspace/model/test/HibernateSearchTest.java
@@ -1,18 +1,28 @@
 package com.researchspace.model.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import com.researchspace.model.FileProperty;
 import com.researchspace.model.inventory.Barcode;
+import com.researchspace.model.inventory.Container;
+import com.researchspace.model.inventory.InventoryFile;
+import com.researchspace.model.inventory.InventoryRecord;
+import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
+import com.researchspace.model.inventory.SampleTemplate;
+import com.researchspace.model.inventory.SubSample;
+import com.researchspace.model.inventory.field.ExtraTextField;
 import com.researchspace.model.permissions.ACLElement;
 import com.researchspace.model.permissions.ConstraintBasedPermission;
 import com.researchspace.model.permissions.PermissionDomain;
 import com.researchspace.model.permissions.PermissionType;
 import com.researchspace.model.permissions.RecordSharingACL;
+import com.researchspace.model.record.TestFactory;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.query.Query;
@@ -21,15 +31,6 @@ import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.junit.jupiter.api.Test;
-
-import com.researchspace.model.FileProperty;
-import com.researchspace.model.inventory.Container;
-import com.researchspace.model.inventory.InventoryFile;
-import com.researchspace.model.inventory.InventoryRecord;
-import com.researchspace.model.inventory.Sample;
-import com.researchspace.model.inventory.SubSample;
-import com.researchspace.model.inventory.field.ExtraTextField;
-import com.researchspace.model.record.TestFactory;
 
 /**
  * Tests lucene indexing and search.
@@ -180,7 +181,7 @@ class HibernateSearchTest extends HibernateTest {
 	private Sample saveComplexSample(Sample sample3) {
 		HibernateSandboxTest t = new HibernateSandboxTest();
 		t.saveRadioAndChoiceDefinitions(dao, sample3.getSTemplate());
-		dao.save(sample3.getSTemplate(), Sample.class);
+		dao.save(sample3.getSTemplate(), SampleTemplate.class);
 		t.saveRadioAndChoiceDefinitions(dao, sample3);
 		return saveSampleInContainer(sample3);
 	}
@@ -191,6 +192,72 @@ class HibernateSearchTest extends HibernateTest {
 		return dao.save(sample, Sample.class);
 	}
 	
+	@SuppressWarnings("unchecked")
+	@Test
+	public void searchSamplesAndSampleTemplates() throws InterruptedException {
+
+		// save a sample and a sample template, both with searchable names
+		Sample sample = TestFactory.createBasicSampleInContainer(testUser);
+		sample.setName("polysearch sample");
+		sample = saveSampleInContainer(sample);
+
+		SampleTemplate template = rf.createSampleTemplate("polysearch template", testUser);
+		template = dao.save(template, SampleTemplate.class);
+
+		Session session = null;
+		Transaction transaction = null;
+		try {
+			session = sf.getCurrentSession();
+			transaction = session.getTransaction();
+			transaction.begin();
+
+			// build lucene index and query
+			FullTextSession fullTextSession = Search.getFullTextSession(sf.getCurrentSession());
+			fullTextSession.createIndexer().startAndWait();
+			QueryBuilder qb = fullTextSession.getSearchFactory().buildQueryBuilder().forEntity(Sample.class).get();
+
+			org.apache.lucene.search.Query lucenceQuery = qb.keyword().onFields("name").matching("polysearch")
+					.createQuery();
+
+			// query targeting SampleEntity finds both the sample and the template
+			Query<SampleEntity> entityQuery = fullTextSession.createFullTextQuery(lucenceQuery, SampleEntity.class);
+			List<SampleEntity> sampleEntities = entityQuery.getResultList();
+			assertNotNull(sampleEntities);
+			assertEquals(2, sampleEntities.size());
+			Collections.sort(sampleEntities, (se1, se2) -> se1.getName().compareTo(se2.getName()));
+			assertEquals("polysearch sample", sampleEntities.get(0).getName());
+			assertInstanceOf(Sample.class, sampleEntities.get(0));
+			assertEquals("polysearch template", sampleEntities.get(1).getName());
+			assertInstanceOf(SampleTemplate.class, sampleEntities.get(1));
+
+			// the same query targeting Sample finds only the sample
+			Query<Sample> sampleQuery = fullTextSession.createFullTextQuery(lucenceQuery, Sample.class);
+			List<Sample> samples = sampleQuery.getResultList();
+			assertNotNull(samples);
+			assertEquals(1, samples.size());
+			assertEquals("polysearch sample", samples.get(0).getName());
+
+			// and targeting SampleTemplate finds only the template
+			Query<SampleTemplate> templateQuery = fullTextSession.createFullTextQuery(lucenceQuery, SampleTemplate.class);
+			List<SampleTemplate> templates = templateQuery.getResultList();
+			assertNotNull(templates);
+			assertEquals(1, templates.size());
+			assertEquals("polysearch template", templates.get(0).getName());
+
+			transaction.commit();
+
+		} catch (Exception e) {
+			if (transaction != null) {
+				transaction.rollback();
+			}
+			throw e;
+		} finally {
+			if (session != null) {
+				session.close();
+			}
+		}
+	}
+
 	@SuppressWarnings("unchecked")
 	@Test
 	public void searchSubSamples() throws InterruptedException {

--- a/src/test/java/com/researchspace/model/test/HibernateTest.java
+++ b/src/test/java/com/researchspace/model/test/HibernateTest.java
@@ -47,6 +47,8 @@ import com.researchspace.model.inventory.InstrumentTemplate;
 import com.researchspace.model.inventory.InventoryFile;
 import com.researchspace.model.inventory.InventoryRecord;
 import com.researchspace.model.inventory.Sample;
+import com.researchspace.model.inventory.SampleEntity;
+import com.researchspace.model.inventory.SampleTemplate;
 import com.researchspace.model.inventory.SubSample;
 import com.researchspace.model.inventory.SubSampleNote;
 import com.researchspace.model.inventory.field.ExtraNumberField;
@@ -168,11 +170,11 @@ public abstract class HibernateTest {
 
   protected void saveParentTemplateForSample(Sample sample) {
     saveRadioAndChoiceDefinitions(dao, sample.getSTemplate());
-    dao.save(sample.getSTemplate(), Sample.class);
+    dao.save(sample.getSTemplate(), SampleTemplate.class);
   }
 
   //util method to save radio/choice definitions
-  protected void saveRadioAndChoiceDefinitions(TestDao dao2, Sample complexSample) {
+  protected void saveRadioAndChoiceDefinitions(TestDao dao2, SampleEntity complexSample) {
     complexSample.getActiveFields().stream().filter(f -> FieldType.CHOICE.equals(f.getType()))
         .map(field -> (InventoryChoiceField) field)
         .forEach(cf -> dao2.save(cf.getChoiceDef(), InventoryChoiceFieldDef.class));
@@ -199,7 +201,8 @@ public abstract class HibernateTest {
         InventoryDateField.class, InventoryTimeField.class, InventoryReferenceField.class,
         InventoryTextField.class, InventoryChoiceField.class, InventoryRadioField.class,
         InventoryAttachmentField.class, AttachmentFieldForm.class, URIFieldForm.class,
-        UriField.class, InventoryUriField.class, Sample.class, SubSample.class, AbstractForm.class,
+        UriField.class, InventoryUriField.class, SampleEntity.class, SampleTemplate.class,
+        Sample.class, SubSample.class, AbstractForm.class,
         Barcode.class, DigitalObjectIdentifier.class, ExtraNumberField.class, ExtraTextField.class,
         SubSampleNote.class, Container.class, ContainerLocation.class, InventoryFile.class,
         InventoryRadioFieldDef.class, InventoryChoiceFieldDef.class, ListOfMaterials.class,


### PR DESCRIPTION
## Description ##

The rspace-core-model side of RSDEV-1065. It extracts a shared abstract
`SampleEntity` base class so that `Sample` and `SampleTemplate` become distinct
concrete entities, instead of a `SampleTemplate` being a `Sample` flagged with
`template = 1`. Both map to the existing single `Sample` table via single-table
inheritance with a `DTYPE` discriminator.

This is the model-layer change that rspace-web #839 builds on. It is a
structural / technical-debt refactor that preserves existing sample and template
behaviour.

Main changes:
- New abstract `SampleEntity` base (shared fields, sub-samples, quantity, and
  copy logic) extending `InventoryRecord`.
- `Sample` slimmed to sample-specific concerns; new `SampleTemplate` concrete
  entity carrying the template-specific behaviour.
- `RecordFactory` / `IRecordFactory` gain `createSampleTemplate(...)`, and
  `createSample(..., SampleTemplate)` / `createComplexSampleTemplate(...)` are
  updated to the new types.
- Reserved-field-name sets and copy / duplicate paths moved onto
  `SampleEntity` and `SampleTemplate`.

## Related PRs ##

- rspace-os/rspace-web#839 (RSDEV-1065): the consumer that uses this new
  hierarchy (DAOs, services, REST API, and the Liquibase migration that adds and
  backfills the `DTYPE` discriminator). It depends on this PR and pins
  `rspace-core-model` to `RSDEV-1065-model-SNAPSHOT` until this is released.

## Design decisions ##

- Single-table inheritance over the existing `Sample` table using Hibernate's
  default `DTYPE` discriminator (`@Inheritance(SINGLE_TABLE)` on `SampleEntity`,
  `@DiscriminatorValue` "Sample" / "SampleTemplate" on the subclasses),
  mirroring the existing `InstrumentEntity` / `InstrumentTemplate` hierarchy for
  consistency.
- `SampleEntity` is `@Audited`, so Envers tracks both subtypes; the discriminator
  anchors historical revisions (the web PR backfills `DTYPE` in both `Sample` and
  `Sample_AUD`).
- `SampleTemplate` overrides template-specific behaviour: its own reserved field
  names, `getType()` = SAMPLE_TEMPLATE, `getGlobalIdPrefix()` = IT,
  `copyFromTemplate` returns a `Sample`, `copyToTemplate` is rejected, and file
  attachments are not supported.
- `copy` / `shallowCopy` reuse the same generic pattern already established by
  `InstrumentEntity`, so the two hierarchies stay structurally identical.
- The legacy boolean `template` flag is no longer the source of truth in the
  model; code discriminates by entity type.

## Testing notes ##

- All tests here are surefire unit tests (`mvn test`); there are no MVC/IT tests
  in this repo. Run a single class with `mvn test -Dtest=ClassName`.
- The `Hibernate*Test` classes build a real Hibernate `SessionFactory` (with a
  filesystem Lucene index under `hibtest/`) and exercise persistence, Envers
  auditing, and full-text search across `SampleEntity` / `Sample` /
  `SampleTemplate`.
- Key unit coverage: `SampleTemplateTest`, `RecordFactoryTest` (template
  creation, sample-from-template, sub-sample default unit), and
  `InventoryRecordReservedFieldNamesTest` (per-type reserved names).
- Consumed by rspace-web #839 via JitPack as `RSDEV-1065-model-SNAPSHOT`. Before
  or at merge, set a proper release version and add a `Changelog.md` entry so
  #839 can depend on the released artifact instead of the branch SNAPSHOT.
