### PR TITLE
RSDEV-1219: Adding `isEditable`column on `InstrumentTemplate` to support default PIDINST template

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 Summary of important or breaking changes.
 
+## 2.31.0 2026-07-24
+- Added `isEditable` flag to the Instrument Template 
+
 ## 2.30.0 2026-06-25
 - Added `com.researchspace.b2inst.model` PIDINST/B2INST domain wrappers
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rspace-core-model</artifactId>
-  <version>2.30.0</version>
+  <version>2.31.0</version>
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>

--- a/src/main/java/com/researchspace/model/inventory/InstrumentTemplate.java
+++ b/src/main/java/com/researchspace/model/inventory/InstrumentTemplate.java
@@ -2,6 +2,7 @@ package com.researchspace.model.inventory;
 
 import com.researchspace.model.User;
 import com.researchspace.model.core.GlobalIdPrefix;
+import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.Transient;
@@ -26,6 +27,16 @@ public class InstrumentTemplate extends InstrumentEntity {
   private static final String TEMPLATE_MOVE_NOT_ALLOWED =
       "InstrumentTemplate cannot be moved or attached to containers";
 
+  /**
+   * Whether this template may be edited, deleted or transferred. Defaults to {@code true}; the only
+   * writer of {@code false} is the seeder of a default (system) template, which must stay read-only
+   * for everyone including its owning sysadmin. A duplicate of a template is a fresh instance that
+   * keeps the default {@code true}, and an instrument created from a template has no such flag.
+   * Lives on the concrete template (not {@link InstrumentEntity}) because editability is only
+   * meaningful for templates; single-table inheritance keeps the column on the shared table.
+   */
+  private boolean editable = true;
+
   public InstrumentTemplate() {
     super();
   }
@@ -34,6 +45,20 @@ public class InstrumentTemplate extends InstrumentEntity {
     this();
     shallowCopyBasicFields(originInstrument, this);
     copy(originInstrument, this, this::defaultNameCopy, currentuser);
+  }
+
+  /**
+   * Explicit getter (wins over the class-level Lombok {@code @Getter}) so the persisted column is
+   * named {@code isEditable} rather than the JavaBeans default {@code editable}. Envers picks the
+   * property up automatically via the class-level {@code @Audited}.
+   */
+  @Column(name = "isEditable", nullable = false)
+  public boolean isEditable() {
+    return editable;
+  }
+
+  public void setEditable(boolean editable) {
+    this.editable = editable;
   }
 
 

--- a/src/test/java/com/researchspace/model/inventory/InstrumentTemplateTest.java
+++ b/src/test/java/com/researchspace/model/inventory/InstrumentTemplateTest.java
@@ -12,6 +12,7 @@ import com.researchspace.model.core.GlobalIdPrefix;
 import com.researchspace.model.inventory.field.InventoryEntityField;
 import com.researchspace.model.inventory.field.InventoryTextField;
 import com.researchspace.model.record.TestFactory;
+import javax.persistence.Column;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -89,6 +90,45 @@ public class InstrumentTemplateTest {
     assertEquals(template, copiedInstrument.getInstrumentTemplate());
     assertEquals(template.getVersion(), copiedInstrument.getTemplateLinkedVersion());
     assertEquals(1L, copiedInstrument.getVersion());
+  }
+
+  @Test
+  @DisplayName("An instrument template is editable by default")
+  public void isEditableTrueByDefault() {
+    assertTrue(template.isEditable());
+  }
+
+  @Test
+  @DisplayName("Duplicating a locked (non-editable) template yields an editable copy")
+  public void copyOfNonEditableTemplateIsEditable() {
+    template.setEditable(false);
+    assertFalse(template.isEditable());
+
+    InstrumentTemplate copied = (InstrumentTemplate) template.copy(anyUser);
+    assertTrue(copied.isEditable(), "a duplicate of a locked template must be editable");
+  }
+
+  @Test
+  @DisplayName("An instrument can still be created from a locked template")
+  public void instrumentCanBeCreatedFromNonEditableTemplate() {
+    template.setEditable(false);
+
+    // instruments carry no editability flag at all (it is template-only), so an instrument built
+    // from a locked template is an ordinary instrument
+    Instrument fromTemplate = (Instrument) template.copyFromTemplate(anyUser);
+    assertEquals(template, fromTemplate.getInstrumentTemplate());
+  }
+
+  @Test
+  @DisplayName("isEditable is mapped non-nullable so existing rows never hydrate as locked")
+  public void isEditableColumnIsMappedNonNullable() throws NoSuchMethodException {
+    Column column = InstrumentTemplate.class.getMethod("isEditable").getAnnotation(Column.class);
+    assertNotNull(column, "isEditable() must carry an explicit @Column mapping");
+    assertEquals("isEditable", column.name());
+    assertFalse(
+        column.nullable(),
+        "isEditable must be non-nullable to match the not-null, default-1 schema so pre-existing"
+            + " rows stay editable rather than hydrating a NULL as false");
   }
 
   @Test


### PR DESCRIPTION
related PR:https://github.com/rspace-os/rspace-web/pull/964