### PR TITLE
RSDEV-900 Keep temporary autosave document copies out of the Lucene index

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rspace-core-model</artifactId>
-  <version>3.1.0</version>
+  <version>3.2.0</version>
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>

--- a/src/main/java/com/researchspace/model/record/StructuredDocument.java
+++ b/src/main/java/com/researchspace/model/record/StructuredDocument.java
@@ -35,6 +35,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmb
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyValue;
+import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.RoutingBinderRef;
 
 import com.researchspace.core.util.SecureStringUtils;
 import com.researchspace.model.Group;
@@ -52,7 +53,7 @@ import com.researchspace.model.field.FieldType;
  */
 @Entity
 @Audited
-@Indexed
+@Indexed(routingBinder = @RoutingBinderRef(type = TemporaryDocRoutingBinder.class))
 public class StructuredDocument extends Record implements TaggableElnRecord {
 
 	/** Default name when creating new Structured Document */

--- a/src/main/java/com/researchspace/model/record/TemporaryDocRoutingBinder.java
+++ b/src/main/java/com/researchspace/model/record/TemporaryDocRoutingBinder.java
@@ -1,0 +1,49 @@
+package com.researchspace.model.record;
+
+import org.hibernate.search.mapper.pojo.bridge.RoutingBridge;
+import org.hibernate.search.mapper.pojo.bridge.binding.RoutingBindingContext;
+import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.RoutingBinder;
+import org.hibernate.search.mapper.pojo.bridge.runtime.RoutingBridgeRouteContext;
+import org.hibernate.search.mapper.pojo.route.DocumentRoutes;
+
+/**
+ * Keeps temporary autosave copies of documents out of the Lucene index.
+ * <p>
+ * Every edit session creates a working copy of the document being edited (see
+ * {@code RecordManager#saveTemporaryDocument} in rspace-web) which shares the
+ * original's name, tags and form. If indexed, such copies show up in workspace
+ * search as phantom duplicates: they have no folder path, no fields and
+ * version 0, and operations like move fail on them. They are also re-saved on
+ * every autosave, so excluding them avoids pointless index writes during
+ * editing.
+ */
+public class TemporaryDocRoutingBinder implements RoutingBinder {
+
+	@Override
+	public void bind(RoutingBindingContext context) {
+		context.dependencies().use("temporaryDoc");
+		context.bridge(StructuredDocument.class, new TemporaryDocRoutingBridge());
+	}
+
+	static class TemporaryDocRoutingBridge implements RoutingBridge<StructuredDocument> {
+
+		@Override
+		public void route(DocumentRoutes routes, Object entityIdentifier, StructuredDocument document,
+				RoutingBridgeRouteContext context) {
+			if (document.isTemporaryDoc()) {
+				routes.notIndexed();
+			} else {
+				routes.addRoute();
+			}
+		}
+
+		@Override
+		public void previousRoutes(DocumentRoutes routes, Object entityIdentifier, StructuredDocument document,
+				RoutingBridgeRouteContext context) {
+			// The temporary flag never flips on a live entity, but always emitting the
+			// default route means update/delete events clean up any stale index entry,
+			// e.g. one written before this binder existed.
+			routes.addRoute();
+		}
+	}
+}

--- a/src/test/java/com/researchspace/model/record/TemporaryDocRoutingBinderTest.java
+++ b/src/test/java/com/researchspace/model/record/TemporaryDocRoutingBinderTest.java
@@ -1,0 +1,51 @@
+package com.researchspace.model.record;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.hibernate.search.mapper.pojo.route.DocumentRoutes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.researchspace.model.record.TemporaryDocRoutingBinder.TemporaryDocRoutingBridge;
+
+public class TemporaryDocRoutingBinderTest {
+
+	private final TemporaryDocRoutingBridge bridge = new TemporaryDocRoutingBridge();
+	private DocumentRoutes routes;
+	private StructuredDocument doc;
+
+	@BeforeEach
+	public void setUp() {
+		routes = mock(DocumentRoutes.class);
+		doc = TestFactory.createAnySD();
+		doc.setId(1L);
+	}
+
+	@Test
+	public void normalDocumentIsIndexed() {
+		bridge.route(routes, doc.getId(), doc, null);
+
+		verify(routes).addRoute();
+		verifyNoMoreInteractions(routes);
+	}
+
+	@Test
+	public void temporaryDocumentIsNotIndexed() {
+		doc.setTemporaryDoc(true);
+		bridge.route(routes, doc.getId(), doc, null);
+
+		verify(routes).notIndexed();
+		verifyNoMoreInteractions(routes);
+	}
+
+	@Test
+	public void previousRoutesAlwaysIncludeDefaultRouteSoStaleEntriesGetDeleted() {
+		doc.setTemporaryDoc(true);
+		bridge.previousRoutes(routes, doc.getId(), doc, null);
+
+		verify(routes).addRoute();
+		verifyNoMoreInteractions(routes);
+	}
+}


### PR DESCRIPTION
## Description

Every edit session in rspace-web creates a temporary working copy of the document being edited (`RecordManager#saveTemporaryDocument`). The copy shares the original's name, tags and form, but has no fields, no folder parent, and stays at version 0. Because `StructuredDocument` was indexed unconditionally, these copies appeared in workspace search as phantom duplicates that cannot be opened usefully or moved, and bulk move operations that included one failed with a 500 ("Attempted to get parent folder of root folder").

This adds a `TemporaryDocRoutingBinder` to `StructuredDocument`'s `@Indexed` annotation so temporary copies are routed to `notIndexed()`. `previousRoutes` always emits the default route, so the next update of a copy that is already in an index (written before this binder existed) deletes the stale entry. Excluding the copies also removes the pointless reindex of the temp copy on every autosave tick.

Related `rspace-web` PR: https://github.com/rspace-os/rspace-web/pull/1010

🤖 Generated with [Claude Code](https://claude.com/claude-code)