### PR TITLE
RSDEV-1291: take rspace-parent 3.1.0 (Shiro 3.0.0), release 3.3.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 Summary of important or breaking changes.
 
+## 3.3.0 2026-08-20
+ - rspace-parent 3.0.0 -> 3.1.0, bringing Shiro 2.1.0 -> 3.0.0
+
 ## 3.2.0 2026-08-07
  - Keep temporary autosave document copies out of the Lucene index
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rspace-core-model</artifactId>
-  <version>3.2.1</version>
+  <version>3.3.0</version>
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>
-    <version>3.0.0</version>
+    <version>3.1.0</version>
   </parent>
   <repositories>
     <repository>


### PR DESCRIPTION
Bumps rspace-parent from 3.0.0 to 3.1.0, which moves `shiro.version` from 2.1.0 to 3.0.0, and releases rspace-core-model 3.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)